### PR TITLE
Add hls support when viewing an hls only video from Youtube live

### DIFF
--- a/plugin/YouTubePlayer.py
+++ b/plugin/YouTubePlayer.py
@@ -282,7 +282,12 @@ class YouTubePlayer():
 
         (links, video) = self.extractVideoLinksFromYoutube(video, params)
 
-        video[u"video_url"] = self.selectVideoQuality(params, links)
+        if "hlsvp" in video:
+            #hls selects the quality based on available bitrate (adaptive quality), no need to select it here
+            video[u"video_url"] = video[u"hlsvp"]
+            self.common.log("Using hlsvp url %s" % video[u"video_url"])
+        else:
+            video[u"video_url"] = self.selectVideoQuality(params, links)
 
         (video, status) = self.checkForErrors(video)
 
@@ -321,6 +326,9 @@ class YouTubePlayer():
 
         if flashvars.has_key(u"ttsurl"):
             video[u"ttsurl"] = flashvars[u"ttsurl"]
+
+        if flashvars.has_key(u"hlsvp"):                               
+            video[u"hlsvp"] = flashvars[u"hlsvp"]    
 
         for url_desc in flashvars[u"url_encoded_fmt_stream_map"].split(u","):
             url_desc_map = cgi.parse_qs(url_desc)
@@ -384,7 +392,7 @@ class YouTubePlayer():
 
         links = self.scrapeWebPageForVideoLinks(result, video)
 
-        if len(links) == 0:
+        if len(links) == 0 and not( "hlsvp" in video ):
             self.common.log(u"Couldn't find video url- or stream-map.")
 
             if not u"apierror" in video:

--- a/unittests/TestYouTubePlayer.py
+++ b/unittests/TestYouTubePlayer.py
@@ -416,6 +416,19 @@ class TestYouTubePlayer(BaseTestCase.BaseTestCase):
 
         assert(result[0].has_key(35))
 
+    def test_buildVideoObject_with_hls(self):
+        sys.modules["__main__"].core._fetchPage.return_value = {"status": 200, "content": self.readTestInput("live-video-hls-page-S_pMsJw-_oA.html", False)}
+        sys.modules["__main__"].subtitles.getLocalFileSource.return_value = ""
+        sys.modules["__main__"].common.parseDOM.return_value = []
+        params = {"videoid": "some_id"}
+        player = YouTubePlayer()
+        player.getInfo = Mock()
+        video = {"videoid": "some_id", "Title": "someTitle"}
+        player.getInfo.return_value = (video, 200)
+
+        (video, status) = player.buildVideoObject(params)
+        
+        assert(video["video_url"] == "http://www.youtube.com/api/manifest/hls_variant/id/S_pMsJw-_oA.2/sparams/cp%2Cid%2Cip%2Cipbits%2Cmaudio%2Cplaylist_type%2Cpmbypass%2Csource%2Cexpire/expire/1364700604/playlist_type/DVR/ipbits/8/upn/Ftpj_wWBeuQ/signature/4B46E966BDE27C0772BA90DE72F0B083F7C44E5A.6F1348A5EE63E4167F1E03C1DE268DABA3EB836E/fexp/932000%2C906383%2C902000%2C919512%2C929903%2C931202%2C900821%2C900823%2C931203%2C931401%2C908529%2C919373%2C930803%2C906836%2C920201%2C929602%2C930101%2C930603%2C900824%2C910223/ip/205.178.10.177/key/yt1/maudio/1/sver/3/cp/U0hVSVdLTl9FTkNONV9PRVJHOmtkY0VJTkJQay02/pmbypass/yes/source/yt_live_broadcast/file/index.m3u8")
 
 
 if __name__ == '__main__':

--- a/unittests/resources/live-video-hls-page-S_pMsJw-_oA.html
+++ b/unittests/resources/live-video-hls-page-S_pMsJw-_oA.html
@@ -1,0 +1,3526 @@
+
+    <!DOCTYPE html><html lang="en" data-cast-api-enabled="true"><head>  <link id="css-1318574089" rel="stylesheet" href="http://s.ytimg.com/yts/cssbin/www-core-vfllKOn3r.css">
+
+    <script>var ytcsi = {data_: {tick: {},info: {}},tick: function(l, t) {ytcsi.data_.tick[l] = t || +new Date();},info: function(k, v) {ytcsi.data_.info[k] = v;}};ytcsi.tick('start');if (document.webkitVisibilityState == 'prerender') {ytcsi.info('prerender', 1);document.addEventListener('webkitvisibilitychange', function() {ytcsi.tick('start');}, false);}try {ytcsi.pt_ = (window.chrome && chrome.csi().pageT ||window.gtbExternal && gtbExternal.pageT() ||window.external && external.pageT);if (ytcsi.pt_) {ytcsi.info('pt', Math.floor(ytcsi.pt_));}} catch(e) {}</script>
+<title>LCS 2013 NA Spring W7D1 (English) - YouTube</title><meta http-equiv="x-dns-prefetch-control" content="on"><link rel="dns-prefetch" href="//i1.ytimg.com"><link rel="dns-prefetch" href="//i2.ytimg.com"><link rel="dns-prefetch" href="//i3.ytimg.com"><link rel="dns-prefetch" href="//i4.ytimg.com"><link rel="dns-prefetch" href="https://lh3.googleusercontent.com"><link rel="dns-prefetch" href="https://lh4.googleusercontent.com"><link rel="dns-prefetch" href="https://lh5.googleusercontent.com"><link rel="dns-prefetch" href="https://lh6.googleusercontent.com"><link rel="search" type="application/opensearchdescription+xml" href="http://www.youtube.com/opensearch?locale=en_US" title="YouTube Video Search"><link rel="shortcut icon" href="http://s.ytimg.com/yts/img/favicon-vfldLzJxy.ico" type="image/x-icon">     <link rel="icon" href="//s.ytimg.com/yts/img/favicon_32-vflWoMFGx.png" sizes="32x32"><link rel="canonical" href="/watch?v=S_pMsJw-_oA"><link rel="alternate" media="handheld" href="http://m.youtube.com/watch?v=S_pMsJw-_oA"><link rel="alternate" media="only screen and (max-width: 640px)" href="http://m.youtube.com/watch?v=S_pMsJw-_oA"><link rel="shortlink" href="http://youtu.be/S_pMsJw-_oA">    <meta name="title" content="LCS 2013 NA Spring W7D1 (English)">
+
+    <meta name="description" content="">
+
+    <meta name="keywords" content="">
+
+    <link rel="alternate" type="application/json+oembed" href="http://www.youtube.com/oembed?url=http%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DS_pMsJw-_oA&amp;format=json" title="LCS 2013 NA Spring W7D1 (English)">
+  <link rel="alternate" type="text/xml+oembed" href="http://www.youtube.com/oembed?url=http%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DS_pMsJw-_oA&amp;format=xml" title="LCS 2013 NA Spring W7D1 (English)">
+
+      <meta property="og:url" content="http://www.youtube.com/watch?v=S_pMsJw-_oA">
+    <meta property="og:title" content="LCS 2013 NA Spring W7D1 (English)">
+    <meta property="og:description" content=" ">
+    <meta property="og:type" content="video">
+    <meta property="og:image" content="http://i4.ytimg.com/vi/S_pMsJw-_oA/mqdefault.jpg?feature=og">
+      <meta property="og:video" content="http://www.youtube.com/v/S_pMsJw-_oA?autohide=1&amp;version=3">
+      <meta property="og:video:type" content="application/x-shockwave-flash">
+      <meta property="og:video:width" content="640">
+      <meta property="og:video:height" content="360">
+    <meta property="og:site_name" content="YouTube">
+    <meta property="fb:app_id" content="87741124305">
+    <meta name="twitter:card" content="player">
+    <meta name="twitter:site" content="@youtube">
+      <meta name="twitter:player" content="https://www.youtube.com/embed/S_pMsJw-_oA">
+      <meta name="twitter:player:width" content="640">
+      <meta name="twitter:player:height" content="360">
+
+      <meta name=attribution content=RiotGamesInc%2Buser/>  
+<script>if (window.ytcsi) {ytcsi.tick("ct");}</script></head><!-- machid: iN3pabkF1UURDQlVQSEJ5aUZkTnotNFdjd21uaEsyWjV5U1AwZ1JlZmZ0bFRnZzVuYmJZcUh3 -->
+
+  <body dir="ltr" class="  ltr  webkit webkit-537    site-left-aligned  exp-new-site-width  exp-watch7-comment-ui  hitchhiker-enabled      guide-enabled guide-collapsed sidebar-expanded   "><div id="body-container"><form name="logoutForm" method="POST" action="/logout"><input type="hidden" name="action_logout" value="1"></form>        <div id="sb-wrapper">
+    <div id="sb-container" class="sb-card sb-off">
+      <div class="sb-card-arrow"></div>
+      <div class="sb-card-border">
+        <div class="sb-card-body-arrow"></div>
+        <div class="sb-card-content" id="sb-target"></div>
+      </div>
+    </div>
+    <div id="sb-onepick-target" class="sb-off"></div>
+  </div>
+
+    
+    <div id="masthead-expanded-acct-sw-container" class="hid"><ul id="masthead-expanded-menu-acct-sw-list"><li class="masthead-expanded-menu-item"><a href="#" onclick="yt.www.masthead.accountswitch.toggle(); return false;">&#8249; Back</a></li>  <li class="masthead-expanded-acct-sw-sel">
+    <p class="masthead-expanded-acct-sw-id1">
+        Stephen Liang<img class="masthead-expanded-acct-sw-sel-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="">
+    </p>
+    <p class="masthead-expanded-acct-sw-id2">
+      thatsnotmath@gmail.com
+    </p>
+      <p class="masthead-expanded-acct-sw-id2"><img class="masthead-expanded-acct-sw-img" src="https://lh6.googleusercontent.com/-tPr-MrUOTdM/AAAAAAAAAAI/AAAAAAAAAAA/azgsCVbCNmA/s12-c-k/photo.jpg" width="12" height="12" alt="">Stephen Liang</p>
+  </li>
+  <li class="masthead-expanded-menu-item">
+    <p class="masthead-expanded-acct-sw-id1">
+        <a href="/signin?authuser=1&amp;action_handle_signin=true&amp;next=%2Fwatch%3Fv%3DS_pMsJw-_oA">Roberto Romero</a>
+    </p>
+    <p class="masthead-expanded-acct-sw-id2">
+      antiregister11@gmail.com
+    </p>
+      <p class="masthead-expanded-acct-sw-id2"><img class="masthead-expanded-acct-sw-img" src="//s.ytimg.com/yts/img/silhouette32-vflu0yzhs.png" width="12" height="12" alt="">antiregister11</p>
+  </li>
+  <li class="masthead-expanded-menu-item">
+    <p class="masthead-expanded-acct-sw-id1">
+        <a href="/signin?authuser=2&amp;action_handle_signin=true&amp;next=%2Fwatch%3Fv%3DS_pMsJw-_oA">Stephen Liang</a>
+    </p>
+    <p class="masthead-expanded-acct-sw-id2">
+      thekiler@gmail.com
+    </p>
+  </li>
+<li class="masthead-expanded-menu-item"><a class="end" href="https://accounts.google.com/AddSession?uilel=0&amp;service=youtube&amp;continue=http%3A%2F%2Fwww.youtube.com%2Fsignin%3Faction_handle_signin%3Dtrue%26authuser%3D-1%26hl%3Den_US%26next%3D%252Fwatch%253Fv%253DS_pMsJw-_oA%26nomobiletemp%3D1&amp;hl=en_US&amp;passive=false">Sign in to another account...</a></li><li class="masthead-expanded-menu-item"><a class="end" href="#" onclick="document.logoutForm.submit(); return false;">Sign out of all accounts</a></li></ul></div>
+    <div id="yt-masthead-container" class="yt-grid-box"><div id="yt-masthead" class="">    <a id="logo-container" href="/" title="YouTube home" class=""><img id="logo" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="YouTube home"></a>
+<div id="yt-masthead-user">
+  <span id="yt-masthead-user-displayname" dir="ltr" class="yt-valign-container" onclick="yt.www.masthead.toggleExpandedMasthead();">
+    thatsnotmath@gmail.com
+  </span>
+
+    <button type="button" id="sb-button-notify" class="sb-notif-off yt-uix-button yt-uix-button-default" onclick=";return false;"  role="button"><span class="yt-uix-button-content">  </span></button>
+  <button onclick="yt.www.masthead.toggleExpandedMasthead();;return false;" class="yt-masthead-user-icon yt-uix-button yt-uix-button-default" type="button" data-orientation="vertical" role="button"><span class="yt-uix-button-content">  <span class="video-thumb ux-thumb yt-thumb-square-27 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img src="https://lh6.googleusercontent.com/-tPr-MrUOTdM/AAAAAAAAAAI/AAAAAAAAAAA/azgsCVbCNmA/s88-c-k/photo.jpg" alt="Thumbnail" width="27" ><span class="vertical-align"></span></span></span></span>
+ </span></button>
+  <span id="yt-masthead-dropdown" onclick="yt.www.masthead.toggleExpandedMasthead();"></span>
+</div><div id="yt-masthead-content"><span class="yt-uix-button-group" id="masthead-upload-button-group"><a href="//www.youtube.com/upload" class="yt-uix-button  start yt-uix-sessionlink yt-uix-button-default" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" data-upsell="upload"><span class="yt-uix-button-content">Upload</span></a><button aria-haspopup="true" type="button" class="end flip yt-uix-button yt-uix-button-default yt-uix-button-empty" onclick=";return false;" data-button-menu-id="upload-button-menu" role="button" aria-label="Creator tools menu"><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""></button></span><ul id="upload-button-menu" class="yt-uix-button-menu yt-uix-button-menu-default" role="menu" aria-haspopup="true" style="display: none"><li id="upload-menu-dashboard" role="menuitem"><a href="/dashboard" class="yt-uix-button-menu-item upload-menu-link"><img class="upload-menu-dashboard" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif">Dashboard</a></li><li id="upload-menu-video-manager" role="menuitem"><a href="/my_videos" class="yt-uix-button-menu-item upload-menu-link"><img class="upload-menu-vm" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif">Video Manager</a></li><li id="upload-menu-analytics" role="menuitem"><a href="https://www.youtube.com/analytics" class="yt-uix-button-menu-item upload-menu-link"><img class="upload-menu-analytics" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif">Analytics</a></li></ul><form id="masthead-search" class="search-form consolidated-form" action="/results" onsubmit="if (_gel(&#39;masthead-search-term&#39;).value == &#39;&#39;) return false;"><button type="submit" id="search-btn" tabindex="2" dir="ltr" onclick="if (_gel(&#39;masthead-search-term&#39;).value == &#39;&#39;) return false; _gel(&#39;masthead-search&#39;).submit(); return false;;return true;" class="search-btn-component search-button yt-uix-button yt-uix-button-default"  role="button"><span class="yt-uix-button-content">Search </span></button><div id="masthead-search-terms" class="masthead-search-terms-border" dir="ltr"><label><input id="masthead-search-term"  class="search-term yt-uix-form-input-bidi" name="search_query" value="" type="text" tabindex="1" title="Search"></label></div></form></div></div></div>
+            <div id="masthead-expanded" class="hid">
+    <div id="masthead-expanded-container" class="with-sandbar">
+      <div id="masthead-expanded-menus-container">
+        <span id="masthead-expanded-menu-shade"></span>
+          <div id="masthead-expanded-menu">
+    <span class="masthead-expanded-menu-header">
+YouTube
+    </span>
+    <ul id="masthead-expanded-menu-list">
+      <li class="masthead-expanded-menu-item">
+        <a href="/user/thatsnotmath?feature=mhee">
+My channel
+        </a>
+      </li>
+      <li class="masthead-expanded-menu-item">
+        <a href="/my_videos?feature=mhee">
+Video Manager
+        </a>
+      </li>
+      <li class="masthead-expanded-menu-item">
+          <a href="/feed/subscriptions?feature=mhee">Subscriptions</a>
+      </li>
+      <li class="masthead-expanded-menu-item">
+        <a href="/account?feature=mhee">
+YouTube settings
+        </a>
+      </li>
+    </ul>
+  </div>
+
+          <div id="masthead-expanded-google-menu">
+    <span class="masthead-expanded-menu-header">
+Google account
+    </span>
+    <div id="masthead-expanded-menu-google-container">
+      <div id="masthead-expanded-menu-google-column1">
+        <ul>
+          <li class="masthead-expanded-menu-item"><a href="https://plus.google.com/u/0/118244301963382140637">Profile</a></li>
+          <li class="masthead-expanded-menu-item"><a href="https://plus.google.com/u/0/stream">Google+</a></li>
+            <li class="masthead-expanded-menu-item"><a href="https://plus.google.com/u/0/settings/privacy">Privacy</a></li>
+          <li class="masthead-expanded-menu-item">
+            <a href="https://plus.google.com/u/0/settings">
+Settings
+            </a>
+          </li>
+        </ul>
+      </div>
+      <div id="masthead-expanded-menu-google-column2">
+        <div id="masthead-expanded-menu-account-container">
+              <img id="masthead-expanded-menu-gaia-photo" alt="" data-src="https://lh6.googleusercontent.com/-tPr-MrUOTdM/AAAAAAAAAAI/AAAAAAAAAAA/azgsCVbCNmA/s28-c-k/photo.jpg">
+  <div id="masthead-expanded-menu-account-info"  class="email-only">
+      <p>Stephen Liang</p>
+    <p id="masthead-expanded-menu-email">thatsnotmath@gmai...</p>
+  </div>
+
+        </div>
+        <ul>
+          <li class="masthead-expanded-menu-item">
+            <a class="end" href="#" onclick="document.logoutForm.submit(); return false;">
+Sign out
+            </a>
+          </li>
+            <li class="masthead-expanded-menu-item">
+                <div class="yt-uix-clickcard masthead-expanded-menu-switch" data-card-class="masthead-card-switch-account">
+    <button type="button" class="yt-uix-clickcard-target yt-uix-button yt-uix-button-link" onclick=";return false;" data-orientation="vertical" data-position="rightbottom" role="button"><span class="yt-uix-button-content">Switch account </span></button>
+    <div class="yt-uix-clickcard-content">
+        <ul id="yt-masthead-multilogin">
+              <li>
+    <a class="yt-masthead-multilogin-user yt-valign" href="/signin?authuser=0&amp;action_handle_signin=true&amp;next=%2Fwatch%3Fv%3DS_pMsJw-_oA">
+      <span class="video-thumb ux-thumb yt-thumb-square-46 yt-masthead-multilogin-user-icon" ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img src="https://lh6.googleusercontent.com/-tPr-MrUOTdM/AAAAAAAAAAI/AAAAAAAAAAA/azgsCVbCNmA/s46-c-k/photo.jpg" alt="Stephen Liang" width="46" ><span class="vertical-align"></span></span></span></span>
+      <span class="yt-masthead-multilogin-user-content yt-valign-container">
+        <span class="yt-masthead-multilogin-user-link" dir="ltr">Stephen Liang</span><br>
+        thatsnotmath@gmail.com
+      </span>
+      <span class="yt-valign-trick"></span>
+          <div class="yt-alert yt-alert-naked yt-alert-success">
+      <div class="yt-alert-icon">
+    <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" class="icon master-sprite" alt="Alert icon">
+  </div>
+
+  </div>
+
+    </a>
+  </li>
+
+              <li>
+    <a class="yt-masthead-multilogin-user yt-valign" href="/signin?authuser=1&amp;action_handle_signin=true&amp;next=%2Fwatch%3Fv%3DS_pMsJw-_oA">
+      <span class="video-thumb ux-thumb yt-thumb-square-46 yt-masthead-multilogin-user-icon" ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img src="//s.ytimg.com/yts/img/silhouette48-vflLdu7sh.png" alt="Roberto Romero" width="46" ><span class="vertical-align"></span></span></span></span>
+      <span class="yt-masthead-multilogin-user-content yt-valign-container">
+        <span class="yt-masthead-multilogin-user-link" dir="ltr">antiregister11</span><br>
+        antiregister11@gmail.com
+      </span>
+      <span class="yt-valign-trick"></span>
+    </a>
+  </li>
+
+              <li>
+    <a class="yt-masthead-multilogin-user yt-valign" href="/signin?authuser=2&amp;action_handle_signin=true&amp;next=%2Fwatch%3Fv%3DS_pMsJw-_oA">
+      <span class="video-thumb ux-thumb yt-thumb-square-46 yt-masthead-multilogin-user-icon" ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img src="//s.ytimg.com/yts/img/silhouette48-vflLdu7sh.png" alt="Stephen Liang" width="46" ><span class="vertical-align"></span></span></span></span>
+      <span class="yt-masthead-multilogin-user-content yt-valign-container">
+        <span class="yt-masthead-multilogin-user-link" dir="ltr">Stephen Liang</span><br>
+        thekiler@gmail.com
+      </span>
+      <span class="yt-valign-trick"></span>
+    </a>
+  </li>
+
+        </ul>
+        <div id="yt-masthead-multilogin-actions" class="yt-grid-box">
+          <button onclick="document.logoutForm.submit();return false;" id="yt-masthead-multilogin-sign-out" class=" yt-uix-button yt-uix-button-link" type="button"  role="button"><span class="yt-uix-button-content">Sign out </span></button>
+
+          <a href="https://accounts.google.com/AddSession?uilel=0&amp;service=youtube&amp;continue=http%3A%2F%2Fwww.youtube.com%2Fsignin%3Faction_handle_signin%3Dtrue%26authuser%3D-1%26hl%3Den_US%26next%3D%252Fwatch%253Fv%253DS_pMsJw-_oA%26nomobiletemp%3D1&amp;hl=en_US&amp;passive=false">Add account</a>
+        </div>
+    </div>
+  </div>
+
+            </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+      </div>
+      <div id="masthead-expanded-sandbar">
+        <div id="masthead-expanded-lists-container">
+          <div id="masthead-expanded-loading-message">Loading...</div>
+        </div>
+      </div>
+      <div class="clear"></div>
+    </div>
+  </div>
+
+
+  <div id="alerts" >
+
+
+</div>
+<div id="header"></div><div id="page-container"><div id="page" class="  watch   clearfix"><div id="guide" >      <div id="guide-container" class="    collapsible-guide ">
+      <div id="guide-main" class="    guide-module collapsed     spf-nolink ">
+    <div class="guide-module-toggle">
+      <span class="guide-module-toggle-icon">
+        <span class="guide-module-toggle-arrow"></span>
+        <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="">
+        <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" id="collapsed-notification-icon">
+      </span>
+      <div class="guide-module-toggle-label">
+        <h3>
+          <span>
+Guide
+            <span class="yt-badge-new">new</span>
+          </span>
+        </h3>
+      </div>
+          <div class="guide-notifications-collapsed">
+    <div id="collapsed-guide-playlist-notification"><div class="collapsed-guide-notification">Playlist updated</div></div>
+    <div id="collapsed-guide-watch-later-notification"><div class="collapsed-guide-notification">Watch Later updated</div></div>
+    <div id="collapsed-guide-sub-notification"><div class="collapsed-guide-notification">Subscriptions updated</div></div>
+  </div>
+
+    </div>
+      <div class="guide-module-content">
+          <div id="gh-personal" class="guide-section guide-header">
+    <div class="guide-item-container personal-item">
+
+      <h3>
+        <a href="/feed/?feature=guide" class="guide-item guide-user-item yt-uix-sessionlink  narrow-item" data-channel-id="UCk1E08zRA00zZSkhjOLzCow" data-upsell="guide" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=g-personal">
+          <span class="display-name">Stephen Liang</span>
+        </a>
+      </h3>
+      <ul class="guide-user-links yt-box">
+        <li id="watch-later-guide-item" data-notification-text="Watch Later updated">
+          <a class="guide-item yt-uix-sessionlink " href="/feed/watch_later" data-channel-id="watch_later" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=g-personal">
+            Watch Later
+          </a>
+        </li>
+        <li>
+          <a class="guide-item yt-uix-sessionlink " href="/feed/history" data-channel-id="history" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=g-personal">
+            Watch History
+          </a>
+        </li>
+          <li id="playlists-guide-item" data-notification-text="Playlist updated">
+            <a class="guide-item yt-uix-sessionlink " href="/feed/playlists" data-channel-id="playlists" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=g-personal">
+              Playlists
+            </a>
+          </li>
+      </ul>
+    </div>
+  </div>
+
+      <hr class="guide-section-separator">
+    <ul class="guide-toplevel">
+        <li class="guide-section guide-static-section guide-section-no-counts guide-system-feeds">
+            <ul class="guide-item-container">
+                  <li>
+    <a class="yt-uix-sessionlink guide-item " href="/feed/what_to_watch"  data-channel-id="what_to_watch" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=g-system">
+      <span class="display-name" title="What to watch">
+        What to watch
+      </span>
+    </a>
+  </li>
+
+
+                  <li>
+    <a class="yt-uix-sessionlink guide-item " href="/feed/subscriptions"  data-channel-id="subscriptions" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=g-system">
+      <span class="display-name" title="My subscriptions">
+        My subscriptions
+      </span>
+    </a>
+  </li>
+
+
+                    <li>
+    <a class="yt-uix-sessionlink guide-item " href="/feed/social"  data-channel-id="social" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=g-system">
+      <span class="display-name" title="Social">
+        Social
+      </span>
+    </a>
+  </li>
+
+
+            </ul>
+        </li>
+        <hr class="guide-section-separator">
+      <li id="guide-subscriptions-section" class="guide-section without-filter">
+          <h3>Subscriptions</h3>
+        <div id="guide-subs-footer-container">
+                <div id="guide-subscriptions-container">
+      <div class="guide-channels-content">
+      <ul  id="guide-channels" class="guide-channels-list guide-item-container yt-uix-scroller filter-has-matches">
+              <li class="guide-channel">
+    <a class="guide-item yt-uix-sessionlink "
+      href="/feed/UC2t5bjwHdUX4vM2g8TRDq5g"
+      title="RiotGamesInc"
+        data-channel-id="UC2t5bjwHdUX4vM2g8TRDq5g"
+      data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=g-channel"
+    >
+        <span class="thumb"><span class="video-thumb ux-thumb yt-thumb-square-18 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/i/2t5bjwHdUX4vM2g8TRDq5g/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" data-thumb-manual="1" alt="Thumbnail" data-group-key="guide-channel-thumbs" width="18" ><span class="vertical-align"></span></span></span></span></span>
+      <span class="display-name">
+        <span>RiotGamesInc</span>
+      </span>
+            <span class="guide-count yt-uix-tooltip" title="New Activity">2</span>
+
+    </a>
+  </li>
+
+
+              <li class="guide-channel">
+    <a class="guide-item yt-uix-sessionlink "
+      href="/feed/UC-teGPup3KKf9hoAg5yJk8Q"
+      title="teamliquidnet"
+        data-channel-id="UC-teGPup3KKf9hoAg5yJk8Q"
+      data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=g-channel"
+    >
+        <span class="thumb"><span class="video-thumb ux-thumb yt-thumb-square-18 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i2.ytimg.com/i/-teGPup3KKf9hoAg5yJk8Q/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" data-thumb-manual="1" alt="Thumbnail" data-group-key="guide-channel-thumbs" width="18" ><span class="vertical-align"></span></span></span></span></span>
+      <span class="display-name">
+        <span>teamliquidnet</span>
+      </span>
+            <span class="guide-count yt-uix-tooltip" title="New Activity">2</span>
+
+    </a>
+  </li>
+
+
+              <li class="guide-channel">
+    <a class="guide-item yt-uix-sessionlink "
+      href="/feed/UCv3nmgyia2M2FU2TAIRXSLw"
+      title="HDstarcraft"
+        data-channel-id="UCv3nmgyia2M2FU2TAIRXSLw"
+      data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=g-channel"
+    >
+        <span class="thumb"><span class="video-thumb ux-thumb yt-thumb-square-18 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/i/v3nmgyia2M2FU2TAIRXSLw/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" data-thumb-manual="1" alt="Thumbnail" data-group-key="guide-channel-thumbs" width="18" ><span class="vertical-align"></span></span></span></span></span>
+      <span class="display-name">
+        <span>HDstarcraft</span>
+      </span>
+            <span class="guide-count yt-uix-tooltip" title="New Activity">4</span>
+
+    </a>
+  </li>
+
+
+              <li class="guide-channel">
+    <a class="guide-item yt-uix-sessionlink "
+      href="/feed/UCZ8D7Qvm0YHm0vZKFl-AFdA"
+      title="HuskyStarcraft"
+        data-channel-id="UCZ8D7Qvm0YHm0vZKFl-AFdA"
+      data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=g-channel"
+    >
+        <span class="thumb"><span class="video-thumb ux-thumb yt-thumb-square-18 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/i/Z8D7Qvm0YHm0vZKFl-AFdA/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" data-thumb-manual="1" alt="Thumbnail" data-group-key="guide-channel-thumbs" width="18" ><span class="vertical-align"></span></span></span></span></span>
+      <span class="display-name">
+        <span>HuskyStarcraft</span>
+      </span>
+            <span class="guide-count yt-uix-tooltip" title="New Activity">42</span>
+
+    </a>
+  </li>
+
+
+        <li id="guide-filter-no-results">
+No channels found
+        </li>
+        <li id="guide-filter-loading-results">
+              <p class="yt-spinner">
+      <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" class="yt-spinner-img" alt="Loading icon">
+
+    <span class="yt-spinner-message">
+        Loading subscriptions
+    </span>
+  </p>
+
+        </li>
+      </ul>
+  </div>
+
+  </div>
+  <hr class="guide-section-separator">
+    <div id="gh-management" class="guide-management">
+    <div class="guide-item-container">
+      <a href="/channels" class="guide-item yt-uix-sessionlink " data-channel-id="guide_builder" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=g-manage">
+        <span class="thumb guide-management-plus-icon">
+          <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="">
+        </span>
+        <span class="guide-management-caption">
+Browse channels
+        </span>
+      </a>
+      <a href="/subscription_manager" class="guide-item yt-uix-sessionlink " data-channel-id="subscription_manager" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=g-manage">
+        <span class="thumb guide-management-settings-icon">
+          <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="">
+        </span>
+        <span class="guide-management-caption">
+Manage subscriptions
+        </span>
+      </a>
+    </div>
+  </div>
+
+
+        </div>
+      </li>
+    </ul>
+  </div>
+
+  </div>
+
+      <div id="watch-context-container" class="guide-module collapsed hid"></div>
+
+  </div>
+
+</div><div id="content" class="">  <div id="watch7-container" class="  transition-content  " itemscope itemid="" itemtype="http://schema.org/VideoObject">
+        <link itemprop="url" href="http://www.youtube.com/watch?v=S_pMsJw-_oA">
+    <meta itemprop="name" content="LCS 2013 NA Spring W7D1 (English)">
+    <meta itemprop="description" content=" ">
+    <meta itemprop="duration" content="PT0M0S">
+    <meta itemprop="unlisted" content="False">
+    <meta itemprop="paid" content="False">
+      <span itemprop="author" itemscope itemtype="http://schema.org/Person">
+        <link itemprop="url" href="http://www.youtube.com/user/LoLChampSeries">
+      </span>
+    <link itemprop="thumbnailUrl" href="http://i4.ytimg.com/vi/S_pMsJw-_oA/hqdefault.jpg">
+    <span itemprop="thumbnail" itemscope itemtype="http://schema.org/ImageObject">
+      <link itemprop="url" href="http://i4.ytimg.com/vi/S_pMsJw-_oA/mqdefault.jpg">
+      <meta itemprop="width" content="320">
+      <meta itemprop="height" content="180">
+    </span>
+      <link itemprop="embedURL" href="http://www.youtube.com/v/S_pMsJw-_oA?autohide=1&amp;version=3">
+      <meta itemprop="playerType" content="Flash">
+      <meta itemprop="width" content="640">
+      <meta itemprop="height" content="360">
+      <meta itemprop="isFamilyFriendly" content="True">
+      <meta itemprop="regionsAllowed" content="AD,AE,AF,AG,AI,AL,AM,AO,AQ,AR,AS,AT,AU,AW,AX,AZ,BA,BB,BD,BE,BF,BG,BH,BI,BJ,BL,BM,BN,BO,BQ,BR,BS,BT,BV,BW,BY,BZ,CA,CC,CD,CF,CG,CH,CI,CK,CL,CM,CN,CO,CR,CU,CV,CW,CX,CY,CZ,DE,DJ,DK,DM,DO,DZ,EC,EE,EG,EH,ER,ES,ET,FI,FJ,FK,FM,FO,FR,GA,GB,GD,GE,GF,GG,GH,GI,GL,GM,GN,GP,GQ,GR,GS,GT,GU,GW,GY,HK,HM,HN,HR,HT,HU,ID,IE,IL,IM,IN,IO,IQ,IR,IS,IT,JE,JM,JO,JP,KE,KG,KH,KI,KM,KN,KP,KR,KW,KY,KZ,LA,LB,LC,LI,LK,LR,LS,LT,LU,LV,LY,MA,MC,MD,ME,MF,MG,MH,MK,ML,MM,MN,MO,MP,MQ,MR,MS,MT,MU,MV,MW,MX,MY,MZ,NA,NC,NE,NF,NG,NI,NL,NO,NP,NR,NU,NZ,OM,PA,PE,PF,PG,PH,PK,PL,PM,PN,PR,PS,PT,PW,PY,QA,RE,RO,RS,RU,RW,SA,SB,SC,SD,SE,SG,SH,SI,SJ,SK,SL,SM,SN,SO,SR,SS,ST,SV,SX,SY,SZ,TC,TD,TF,TG,TH,TJ,TK,TL,TM,TN,TO,TR,TT,TV,TW,TZ,UA,UG,UM,US,UY,UZ,VA,VC,VE,VG,VI,VN,VU,WF,WS,YE,YT,ZA,ZM,ZW">
+
+
+
+
+        <div id="player">
+    <script>if (window.ytcsi) {ytcsi.tick("bf");}</script>
+    <script>var ytplayer = ytplayer || {};ytplayer.config = {"min_version": "8.0.0", "url_v9as2": "http:\/\/s.ytimg.com\/yts\/swfbin\/cps-vfl1cAzuc.swf", "url_v8": "http:\/\/s.ytimg.com\/yts\/swfbin\/cps-vfl1cAzuc.swf", "assets": {"html": "\/html5_player_template", "css": "http:\/\/s.ytimg.com\/yts\/cssbin\/www-player-vflXTLfPF.css", "js": "http:\/\/s.ytimg.com\/yts\/jsbin\/html5player-vfl8kUzgL.js"}, "attrs": {"id": "movie_player"}, "sts": 1579, "html5": false, "params": {"allowscriptaccess": "always", "allowfullscreen": "true", "bgcolor": "#000000"}, "args": {"cust_age": "1001", "allow_embed": 1, "enable_cardio_before_playback": "1", "enablecsi": "1", "ad_slots": "0", "afv_ad_tag_restricted_to_instream": "http:\/\/googleads.g.doubleclick.net\/pagead\/ads?description_url=http%3A%2F%2Fwww.youtube.com%2Fvideo%2FS_pMsJw-_oA\u0026max_ad_duration=15000\u0026ht_id=403863\u0026host=ca-host-pub-9313524775892158\u0026cust_age=1001\u0026client=ca-pub-6219811747049371\u0026lsv=1\u0026ad_type=standardvideo\u0026cust_gender=1\u0026channel=afv_instream%2BVertical_3%2BVertical_36%2BVertical_211%2BVertical_613%2Bafv_instream_us%2Bafv_user_lolchampseries%2Bafv_user_id_vqRdlKsE5Q8mf8YXbdIJLw%2Byt_mpvid_AATZK34iwRw8E45s%2Byt_cid_237841%2Bytdevice_1%2Bytps_default%2Bytel_detailpage\u0026ytdevice=1\u0026loeid=930901%2C924327\u0026video_cpm=6000000\u0026hl=en", "instream": true, "iv_invideo_url": "http:\/\/www.youtube.com\/annotations_invideo\/read2?features=1\u0026mfu=0\u0026pfc=0\u0026video_id=S_pMsJw-_oA", "playlist_module": "http:\/\/s.ytimg.com\/yts\/swfbin\/playlist_module-vflEslKh-.swf", "csi_page_type": "watch7ad", "hl": "en_US", "mpvid": "AATZK34iwRw8E45s", "pltype": "contentlive", "fresca_module": "http:\/\/s.ytimg.com\/yts\/swfbin\/fresca-vflHQpCBx.swf", "streaminglib_module": "http:\/\/s.ytimg.com\/yts\/swfbin\/streaminglib-vflDqhXXm.swf", "fmt_list": "", "iv3_module": "http:\/\/s.ytimg.com\/yts\/swfbin\/iv3_module-vflRg0Dd9.swf", "t": "vjVQa1PpcFMT3OdMhltA9u_vSUXK_xH9CHWvv9n5vqk=", "watermark": ",http:\/\/s.ytimg.com\/yts\/img\/watermark\/youtube_watermark-vflHX6b6E.png,http:\/\/s.ytimg.com\/yts\/img\/watermark\/youtube_hd_watermark-vflAzLcD6.png", "ad_video_pub_id": "ca-pub-6219811747049371", "endscreen_module": "http:\/\/s.ytimg.com\/yts\/swfbin\/endscreen-vflkSOdR2.swf", "autohide": "2", "cbrver": "24.0.1312.56", "iv_module": "http:\/\/s.ytimg.com\/yts\/swfbin\/iv_module-vflO4NlRc.swf", "referrer": null, "title": "LCS 2013 NA Spring W7D1 (English)", "cplatform": "DESKTOP", "length_seconds": 18000, "partnerid": "27", "tk": "1", "ad_channel_code_instream": "afv_instream,Vertical_3,Vertical_36,Vertical_211,Vertical_613,afv_instream_us,afv_user_lolchampseries,afv_user_id_vqRdlKsE5Q8mf8YXbdIJLw,yt_mpvid_AATZK34iwRw8E45s,yt_cid_237841,ytdevice_1,ytps_default,ytel_detailpage", "ps": "live", "live_storyboard_spec": "http:\/\/i4.ytimg.com\/sb\/S_pMsJw-_oA\/storyboard_live_60_3x3_b2\/M$M.jpg?sigh=KKJBiImE8SFpZKZVybRb_r_5MQA#106#60#3#3", "share_icons": "http:\/\/s.ytimg.com\/yts\/swfbin\/sharing-vfl7FVe3A.swf", "is_html5_mobile_device": false, "enablejsapi": 1, "ad_tag": "http:\/\/ad-g.doubleclick.net\/N4061\/pfadx\/com.ytpwmpu.gadgetsandgames\/main_237841;sz=WIDTHxHEIGHT;kvid=S_pMsJw-_oA;kpu=LoLChampSeries;kpid=237841;u=S_pMsJw-_oA|237841;mpvid=AATZK34iwRw8E45s;live=1;plat=pc;kpeid=vqRdlKsE5Q8mf8YXbdIJLw;afct=site_content;afv=1;dc_dedup=1;k21=1;k5=3_36_211_613;kage=23;kar=3;kauth=1;kclt=1;kcr=us;kga=1001;kgender=m;kgg=1;klg=en;kmsrd=1;ko=p;kr=H;kvz=205;longads=1;longform=1;nlfb=1;tves=2;yt_vrallowed=1;ytcat=20;ytdevice=1;ytexp=930901,924327;ytps=default;ytvt=w;!c=237841;!c=live;k2=3;k2=36;k2=211;k2=613;", "streaminglib_preroll": "1", "account_playback_token": "PLapCyllQdzNd7prSDNm8HFmGrp8MTM2NDc2NzEyOUAxMzY0NjgwNzI5", "cos": "X11", "ad_eurl": "http:\/\/www.youtube.com\/video\/S_pMsJw-_oA", "ptk": "RiotGamesInc%2Buser", "cr": "US", "oid": "ctfFcLX4j2ILHoKHYrDogg", "host_language": "en", "iv_load_policy": 1, "watch_ajax_token": "PR9Y4ZESG2mvXC9IliCsMfFEBGd8MTM2NDc2NzEzMEAxMzY0NjgwNzMw", "fexp": "930901,924327,932000,906383,902000,919512,929903,931202,900821,900823,931203,931401,908529,919373,930803,906836,920201,929602,930101,930603,926403,900824,910223", "afv_inslate_ad_tag": "http:\/\/googleads.g.doubleclick.net\/pagead\/ads?description_url=http%3A%2F%2Fwww.youtube.com%2Fvideo%2FS_pMsJw-_oA\u0026max_ad_duration=15000\u0026ht_id=403863\u0026host=ca-host-pub-9313524775892158\u0026cust_age=1001\u0026client=ca-pub-6219811747049371\u0026lsv=1\u0026ad_type=userchoice\u0026cust_gender=1\u0026hl=en\u0026ytdevice=1\u0026loeid=930901%2C924327", "ad_preroll": "1", "livestream": 1, "ad_host": "ca-host-pub-9313524775892158", "cbr": "Chrome", "sk": "G4pXb1FYLYH7J5l8KwACdIxqIPATUyHoR", "plid": "AATZK34iCUtUI7Wl", "delay": "30", "enable_cardio": 1, "ad_host_tier": "403863", "cid": 237841, "pyv_in_related_cafe_experiment_id": "", "keywords": "", "ad_flags": 0, "video_wall": 1, "ucid": "UCvqRdlKsE5Q8mf8YXbdIJLw", "hlsvp": "http:\/\/www.youtube.com\/api\/manifest\/hls_variant\/id\/S_pMsJw-_oA.2\/sparams\/cp%2Cid%2Cip%2Cipbits%2Cmaudio%2Cplaylist_type%2Cpmbypass%2Csource%2Cexpire\/expire\/1364700604\/playlist_type\/DVR\/ipbits\/8\/upn\/Ftpj_wWBeuQ\/signature\/4B46E966BDE27C0772BA90DE72F0B083F7C44E5A.6F1348A5EE63E4167F1E03C1DE268DABA3EB836E\/fexp\/932000%2C906383%2C902000%2C919512%2C929903%2C931202%2C900821%2C900823%2C931203%2C931401%2C908529%2C919373%2C930803%2C906836%2C920201%2C929602%2C930101%2C930603%2C900824%2C910223\/ip\/205.178.10.177\/key\/yt1\/maudio\/1\/sver\/3\/cp\/U0hVSVdLTl9FTkNONV9PRVJHOmtkY0VJTkJQay02\/pmbypass\/yes\/source\/yt_live_broadcast\/file\/index.m3u8", "user_age": 23, "showpopout": 1, "cafe_experiment_id": "", "gut_tag": "\/4061\/ytpwmpu\/main_237841", "ad_logging_flag": 1, "st_module": "http:\/\/s.ytimg.com\/yts\/swfbin\/st_module-vflHyQ6Cz.swf", "user_gender": "m", "rvs": "title=TSM+vs+MRN+-+LCS+2013+NA+Spring+W6D1+%28English%29\u0026length_seconds=4482\u0026id=oSSlOIxK5Bc\u0026author=LoLChampSeries\u0026view_count=11%2C446,title=CLG+vs+DIG+-+LCS+2013+NA+Spring+W6D1+%28English%29\u0026length_seconds=3887\u0026id=IJVMZ005-ik\u0026author=LoLChampSeries\u0026view_count=10%2C757,title=FNC+vs+EG+-+LCS+2013+EU+Spring+W5D1+%28English%29\u0026length_seconds=6981\u0026id=C9U1dyaSlY8\u0026author=LoLChampSeries\u0026view_count=9%2C933,title=MRN+vs+coL+-+LCS+2013+NA+Spring+W6D2+%28English%29\u0026length_seconds=3221\u0026id=VotWnsJgXr0\u0026author=LoLChampSeries\u0026view_count=5%2C719,title=VUL+vs+CLG+-+LCS+2013+NA+Spring+W6D2+%28English%29\u0026length_seconds=5206\u0026id=jr3Xa14qiNI\u0026author=LoLChampSeries\u0026view_count=12%2C100,title=SK+vs+AAA+-+LCS+2013+EU+Spring+W5D1+%28English%29\u0026length_seconds=5827\u0026id=AYMVRTANETM\u0026author=LoLChampSeries\u0026view_count=6%2C197,title=EG+vs+DB+-+LCS+2013+EU+Spring+W5D1+%28English%29\u0026length_seconds=3776\u0026id=w_pZ84XhyuU\u0026author=LoLChampSeries\u0026view_count=7%2C896,title=Fnatic+Best+Play+Ever\u0026length_seconds=164\u0026id=wYCRgOMkz4k\u0026author=LoLChampSeries\u0026view_count=117%2C202,title=Dyrus+Dad\u0026length_seconds=158\u0026id=rWWR-tVObMM\u0026author=LoLChampSeries\u0026view_count=33%2C017,title=SK+vs+DB+-+LCS+2013+EU+Spring+W5D1+%28English%29\u0026length_seconds=3716\u0026id=G6ItDaXOVMI\u0026author=LoLChampSeries\u0026view_count=9%2C131,title=Rivalry%3A+CLG+vs+Curse\u0026length_seconds=138\u0026id=KasOGgf0NnE\u0026author=LoLChampSeries\u0026view_count=72%2C427,title=Bonding+with+CompLexity\u0026length_seconds=144\u0026id=ES2y_TykP_A\u0026author=LoLChampSeries\u0026view_count=23%2C175", "fresca_preroll": "1", "sendtmp": "1", "excluded_ads": "0=1_3", "ptchn": "LoLChampSeries", "c": "WEB", "ad_device": 1, "cust_gender": "1", "video_id": "S_pMsJw-_oA", "afv_ad_tag": "http:\/\/googleads.g.doubleclick.net\/pagead\/ads?description_url=http%3A%2F%2Fwww.youtube.com%2Fvideo%2FS_pMsJw-_oA\u0026max_ad_duration=15000\u0026ht_id=403863\u0026host=ca-host-pub-9313524775892158\u0026cust_age=1001\u0026client=ca-pub-6219811747049371\u0026lsv=1\u0026ad_type=standardvideo\u0026cust_gender=1\u0026channel=afv_instream%2BVertical_3%2BVertical_36%2BVertical_211%2BVertical_613%2Bafv_instream_us%2Bafv_user_lolchampseries%2Bafv_user_id_vqRdlKsE5Q8mf8YXbdIJLw%2Byt_mpvid_AATZK34iwRw8E45s%2Byt_cid_237841%2Bytdevice_1%2Bytps_default%2Bytel_detailpage\u0026ytdevice=1\u0026loeid=930901%2C924327\u0026video_cpm=6000000\u0026hl=en", "adsense_video_doc_id": "yt_S_pMsJw-_oA", "url_encoded_fmt_stream_map": "", "as_launched_in_country": "1", "prefetch_ad_live_stream": true, "afv_video_min_cpm": 6000000, "aftv": true, "live_playback": 1, "loeid": "930901,924327", "no_get_video_log": "1", "vq": "auto", "logwatch": "1", "dclk": true, "auth_timeout": 21600000, "ad3_module": "http:\/\/s.ytimg.com\/yts\/swfbin\/ad3-vflPiUrcj.swf", "fshd": "1", "hlsdvr": "1", "afv_instream_max": 15000, "inactive_skippable_threshold": 600000, "timestamp": 1364680730, "hlsrange": "1", "tmi": "1"}, "url": "http:\/\/s.ytimg.com\/yts\/swfbin\/watch_as3-vfl01dCpm.swf"};</script>    <div id="player-api"></div>
+    <script>
+      (function() {
+        var encoded = [];
+        for (var key in ytplayer.config.args) {
+          encoded.push(encodeURIComponent(key) + '=' + encodeURIComponent(ytplayer.config.args[key]));
+        }
+        var swf = "      \u003cembed type=\"application\/x-shockwave-flash\"     s\u0072c=\"http:\/\/s.ytimg.com\/yts\/swfbin\/watch_as3-vfl01dCpm.swf\"     id=\"movie_player\"    flashvars=\"__flashvars__\"     allowscriptaccess=\"always\" allowfullscreen=\"true\" bgcolor=\"#000000\"\u003e\n  \u003cnoembed\u003e\u003cdiv class=\"yt-alert yt-alert-default yt-alert-error  yt-alert-player\"\u003e  \u003cdiv class=\"yt-alert-icon\"\u003e\n    \u003cimg s\u0072c=\"\/\/s.ytimg.com\/yts\/img\/pixel-vfl3z5WfW.gif\" class=\"icon master-sprite\" alt=\"Alert icon\"\u003e\n  \u003c\/div\u003e\n\u003cdiv class=\"yt-alert-buttons\"\u003e\u003c\/div\u003e\u003cdiv class=\"yt-alert-content\" role=\"alert\"\u003e    \u003cspan class=\"yt-alert-vertical-trick\"\u003e\u003c\/span\u003e\n    \u003cdiv class=\"yt-alert-message\"\u003e\n            You need Adobe Flash Player to watch this video. \u003cbr\u003e \u003ca href=\"http:\/\/get.adobe.com\/flashplayer\/\"\u003eDownload it from Adobe.\u003c\/a\u003e\n    \u003c\/div\u003e\n\u003c\/div\u003e\u003c\/div\u003e\u003c\/noembed\u003e\n\n";
+        swf = swf.replace('__flashvars__', encoded.join('&'));
+        document.getElementById('player-api').innerHTML = swf;
+      })();
+    </script>
+
+    
+  </div>
+
+
+    <div id="watch7-main-container">
+      <div id="watch7-main" class="clearfix">
+        <div id="watch7-content">
+            <div class="yt-uix-button-panel">
+      <div id="watch7-headline" class="clearfix  yt-uix-expander yt-uix-expander-collapsed">
+    <h1 id="watch-headline-title">
+      
+
+  
+
+
+  <span id="eow-title" class="watch-title  yt-uix-expander-head" dir="ltr" title="LCS 2013 NA Spring W7D1 (English)">
+    LCS 2013 NA Spring W7D1 (English)
+  </span>
+
+    </h1>
+  </div>
+
+    <div id="watch7-user-header" ><a href="/user/LoLChampSeries?feature=watch" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-48 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img src="//i3.ytimg.com/i/vqRdlKsE5Q8mf8YXbdIJLw/1.jpg?v=5125553d" alt="LoLChampSeries" width="48" ><span class="vertical-align"></span></span></span></span></a><a href="/user/LoLChampSeries?feature=watch" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=watch" dir="ltr">LoLChampSeries</a><span class="yt-user-separator">&middot;</span><a class="yt-uix-sessionlink yt-user-videos"href="/user/LoLChampSeries/videos"data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=watch">292 videos</a><br><span id="watch7-subscription-container"><span class=" yt-uix-button-subscription-container yt-uix-button-context-light" ><button type="button" class="yt-uix-subscription-button yt-uix-button yt-uix-button-subscribe-branded" onclick=";return false;" data-style-type="branded" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=watch" data-channel-external-id="UCvqRdlKsE5Q8mf8YXbdIJLw" role="button"><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-subscribe-branded" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><span class="yt-uix-button-content"><span class="subscribe-hh-label">Subscribe</span><span class="subscribed-hh-label">Subscribed</span><span class="unsubscribe-hh-label">Unsubscribe</span> </span></button><span class="yt-subscription-button-subscriber-count-branded-horizontal">220,420</span>  <span class="yt-subscription-button-disabled-mask" title=""></span>
+</span></span><div id="watch7-views-info">  <span class="concurrent-viewers hid watch-view-count">
+    <span class="concurrent-viewers-number" data-video-id="S_pMsJw-_oA"></span>
+watching now
+  </span>
+    <div class="video-extras-sparkbars">
+    <div class="video-extras-sparkbar-likes" style="width: 96.0648148148%"></div>
+    <div class="video-extras-sparkbar-dislikes" style="width: 3.93518518519%"></div>
+  </div>
+  <span class="video-extras-likes-dislikes">
+      <img class="icon-watch-stats-like" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Like">
+  <span class="likes-count">415</span>
+ &nbsp;&nbsp;&nbsp;   <img class="icon-watch-stats-dislike" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Dislike">
+  <span class="dislikes-count">17</span>
+
+  </span>
+
+</div></div>
+      <div id="watch7-action-buttons" class="clearfix">
+    <div id="watch7-sentiment-actions">
+      <span id="watch-like-dislike-buttons" class="yt-uix-button-group actionable " data-vote-state="2" data-button-toggle-group="optional"><span ><button id="watch-like" onclick=";return false;" title="I like this" type="button" class=" yt-uix-button yt-uix-button-text yt-uix-tooltip" data-like-tooltip="I like this" data-orientation="vertical" data-position="bottomright" data-unlike-tooltip="Unlike" data-button-toggle="true" role="button"><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-watch-like" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="I like this" title=""><span class="yt-uix-button-valign"></span></span><span class="yt-uix-button-content">Like </span></button></span><span ><button id="watch-dislike" onclick=";return false;" title="I dislike this" type="button" class=" yt-uix-button yt-uix-button-text yt-uix-tooltip yt-uix-button-empty" data-orientation="vertical" data-position="bottomright" data-button-toggle="true" role="button"><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-watch-dislike" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="I dislike this" title=""><span class="yt-uix-button-valign"></span></span></button></span></span>
+    </div>
+    <div id="watch7-secondary-actions"  class="yt-uix-button-group" data-button-toggle-group="required">
+        <span >
+    <button title="" type="button" class="action-panel-trigger  yt-uix-button-toggled yt-uix-button yt-uix-button-text yt-uix-tooltip" onclick=";return false;" data-trigger-for="action-panel-details" data-button-toggle="true" role="button"><span class="yt-uix-button-content">About </span></button>
+  </span>
+
+        <span >
+    <button title="" type="button" class="action-panel-trigger   yt-uix-button yt-uix-button-text yt-uix-tooltip" onclick=";return false;" data-trigger-for="action-panel-share" data-button-toggle="true" role="button"><span class="yt-uix-button-content">Share </span></button>
+  </span>
+
+          <span >
+    <button title="" type="button" class="action-panel-trigger   yt-uix-button yt-uix-button-text yt-uix-tooltip" onclick=";return false;" data-upsell="playlist" data-trigger-for="action-panel-addto" data-button-toggle="true" role="button"><span class="yt-uix-button-content">Add to </span></button>
+  </span>
+
+        <span >
+    <button title="Statistics" type="button" class="action-panel-trigger   yt-uix-button yt-uix-button-text yt-uix-tooltip yt-uix-button-empty" onclick=";return false;" data-trigger-for="action-panel-stats" data-button-toggle="true" role="button"><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-action-panel-stats" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Statistics" title=""><span class="yt-uix-button-valign"></span></span></button>
+  </span>
+
+        <span >
+    <button title="Report" type="button" class="action-panel-trigger   yt-uix-button yt-uix-button-text yt-uix-tooltip yt-uix-button-empty" onclick=";return false;" data-trigger-for="action-panel-report" data-button-toggle="true" role="button"><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-action-panel-report" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Report" title=""><span class="yt-uix-button-valign"></span></span></button>
+  </span>
+
+    </div>
+  </div>
+
+      <div id="watch7-action-panels" class="yt-uix-button-panel">
+      <div id="action-panel-details" class="action-panel-content ">
+    <div id="watch-description" class="yt-uix-expander yt-uix-expander-collapsed yt-uix-button-panel">
+      <div id="watch-description-content" >
+        <div id="watch-description-clip">
+          <p id="watch-uploader-info">
+            <strong>Streamed live on <span id="eow-date" class="watch-video-date" >Mar 30, 2013</span>
+</strong>
+          </p>
+          <div id="watch-description-text">
+            <p id="eow-description" ><em>No description available.</em></p>
+          </div>
+            <div id="watch-description-extras">
+    <ul class="watch-extras-section">
+      <li>
+        <h4 class="title">
+Category
+        </h4>
+        <div class="content">
+              <p id="eow-category"><a href="/gaming">Gaming</a></p>
+
+        </div>
+      </li>
+
+
+        <li>
+          <h4 class="title">License</h4>
+          <div class="content">
+              <p id="eow-reuse">
+Standard YouTube License
+  </p>
+
+          </li>
+        </li>
+    </ul>
+  </div>
+
+        </div>
+        <ul id="watch-description-extra-info">
+          
+        </ul>
+      </div>
+
+      <div id="watch-description-toggle" class="yt-uix-expander-head yt-uix-button-panel">
+        <div id="watch-description-expand" class="expand">
+          <button type="button" class="metadata-inline yt-uix-button yt-uix-button-text" onclick=";return false;"  role="button"><span class="yt-uix-button-content">Show more </span></button>
+        </div>
+        <div id="watch-description-collapse" class="collapse">
+          <button type="button" class="metadata-inline yt-uix-button yt-uix-button-text" onclick=";return false;"  role="button"><span class="yt-uix-button-content">Show less </span></button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+      <div id="action-panel-share" class="action-panel-content hid">
+      <div id="watch-actions-share-loading">
+    <div class="action-panel-loading">
+        <p class="yt-spinner">
+      <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" class="yt-spinner-img" alt="Loading icon">
+
+    <span class="yt-spinner-message">
+Loading...
+    </span>
+  </p>
+
+    </div>
+  </div>
+  <div id="watch-actions-share-panel"></div>
+
+  </div>
+
+      <div id="action-panel-addto" class="action-panel-content hid" data-auth-required="true">
+    <div class="action-panel-loading">
+        <p class="yt-spinner">
+      <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" class="yt-spinner-img" alt="Loading icon">
+
+    <span class="yt-spinner-message">
+Loading...
+    </span>
+  </p>
+
+    </div>
+  </div>
+
+      <div id="action-panel-stats" class="action-panel-content hid">
+    <div class="action-panel-loading">
+        <p class="yt-spinner">
+      <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" class="yt-spinner-img" alt="Loading icon">
+
+    <span class="yt-spinner-message">
+Loading...
+    </span>
+  </p>
+
+    </div>
+  </div>
+
+      <div id="action-panel-report" class="action-panel-content hid" data-auth-required="true">
+    <div class="action-panel-loading">
+        <p class="yt-spinner">
+      <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" class="yt-spinner-img" alt="Loading icon">
+
+    <span class="yt-spinner-message">
+Loading...
+    </span>
+  </p>
+
+    </div>
+  </div>
+
+      <div id="action-panel-login" class="action-panel-content hid">
+    <div class="action-panel-login">
+      <a href="https://accounts.google.com/ServiceLogin?hl=en_US&amp;service=youtube&amp;continue=http%3A%2F%2Fwww.youtube.com%2Fsignin%3Faction_handle_signin%3Dtrue%26hl%3Den_US%26next%3D%252Fwatch%253Fv%253DS_pMsJw-_oA%26nomobiletemp%3D1&amp;uilel=3&amp;passive=true" class="yt-uix-button   yt-uix-sessionlink yt-uix-button-default" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg"><span class="yt-uix-button-content">Sign in</span></a>
+      <a href="/signup?next=%2Fwatch%3Fv%3DS_pMsJw-_oA" class="yt-uix-button-alert-link">Sign up</a>
+    </div>
+  </div>
+
+  <div id="action-panel-ratings-disabled" class="action-panel-content hid">
+      <div id="watch-actions-ratings-disabled" class="watch-actions-panel">
+    <em>Ratings have been disabled for this video.</em>
+  </div>
+
+  </div>
+
+  <div id="action-panel-rental-required" class="action-panel-content hid">
+      <div id="watch-actions-rental-required" class="watch-actions-panel">
+    <strong>Rating is available when the video has been rented.</strong>
+  </div>
+
+  </div>
+
+  <div id="action-panel-error" class="action-panel-content hid">
+    <div class="action-panel-error">
+      This feature is not available right now. Please try again later.
+    </div>
+  </div>
+
+    <div id="watch7-action-panel-footer">
+        <hr class="yt-horizontal-rule ">
+
+    </div>
+  </div>
+
+  </div>
+    <div id="watch-discussion">
+
+  </div>
+
+
+        </div>
+        <div id="watch7-sidebar">
+          
+
+        <div class="watch-sidebar-section">
+    <div id="watch-live-comments" class="watch-sidebar-body">
+        
+        <div id="comments-view" data-type="everything" class="">
+
+        <div id="live-comments-section">
+    <div id="live-comments-controls">
+              <form class="comments-post" method="post" action="/comment_servlet?add_comment=1">
+    <div class="yt-alert yt-alert-default yt-alert-error hid comments-post-message">  <div class="yt-alert-icon">
+    <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" class="icon master-sprite" alt="Alert icon">
+  </div>
+<div class="yt-alert-buttons"></div><div class="yt-alert-content" role="alert"></div></div>
+
+    <input type="hidden" name="session_token" value="ZCrOms9WEr_yUdbRbAwqQb_J_9Z8MTM2NDcwMjMzMEAxMzY0NjgwNzMw"/>
+    <input type="hidden" name="video_id" value="S_pMsJw-_oA">
+
+
+    <input type="hidden" name="form_id" value="">
+    <input type="hidden" name="source" value="ls">
+    <input type="hidden" value="" name="reply_parent_id">
+
+<a href="/user/thatsnotmath" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img src="https://lh6.googleusercontent.com/-tPr-MrUOTdM/AAAAAAAAAAI/AAAAAAAAAAA/azgsCVbCNmA/s28-c-k/photo.jpg" alt="Stephen Liang" width="28" ><span class="vertical-align"></span></span></span></span></a><div class="comments-textarea-container " onclick="yt.www.comments.initForm(this, true, true);"><img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" class="comments-textarea-tip"><label class="comments-textarea-label" data-upsell="comment">click to leave a comment</label><textarea id="comments-textarea" disabled="disabled" class="yt-uix-form-input-textarea comments-textarea" onfocus="yt.www.comments.initForm(this, false, true);" data-upsell="comment" name="comment"></textarea></div>
+    <p class="comments-post-buttons needs-focus">
+<span class="comments-post-video-response-link"><a href="/video_response_upload?v=S_pMsJw-_oA">Create a video response</a>&nbsp;or&nbsp;</span><button type="submit" class=" yt-uix-button yt-uix-button-default" onclick=";return true;"  role="button"><span class="yt-uix-button-content">Post </span></button>    </p>
+
+    <p class="comments-remaining needs-focus" data-max-count="200">
+    </p>
+    <p class="comments-threshold-countdown hid">
+    </p>
+  </form>
+
+
+
+
+        <div id="live-comments-setting-scroll" class="live-comments-setting hid">
+    <span id="live-comments-count"></span>
+    <a onclick="yt.www.watch.livecomments.setScroll(true); return false;">Update automatically</a>
+  </div>
+  <div id="live-comments-setting-no-scroll" class="live-comments-setting hid">
+    <a onclick="yt.www.watch.livecomments.setScroll(false); return false;">Disable automatic updates</a>
+  </div>
+
+    </div>
+    <div id="comments-scroller" class="scrollable-comment-list">
+        <ul id="all-comments">
+      
+
+
+  <li class="comment"
+    data-author-id="2B3BuijF7KH6jGiOLVffZQ"
+    data-id="994QsupBok2KRNiT2YUIQiHaE1KjloQfuItMfzopsDQ"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/XxspudzyxX" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/i/2B3BuijF7KH6jGiOLVffZQ/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="XxspudzyxX" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/XxspudzyxX" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">XxspudzyxX</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>so excited!﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="OP5zXPH_yaAxxKwxgGH9eg"
+    data-id="994QsupBok3XgfXatnv3vAZLyk1X0mvPZGC2rlZvQJw"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/Pils76" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/i/OP5zXPH_yaAxxKwxgGH9eg/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Pils76" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/Pils76" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Pils76</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>KArthus not op﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="2B3BuijF7KH6jGiOLVffZQ"
+    data-id="994QsupBok1jq8Rv4-Q7XTcEWI-G0BsT8M3SYg__YhE"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/XxspudzyxX" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/i/2B3BuijF7KH6jGiOLVffZQ/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="XxspudzyxX" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/XxspudzyxX" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">XxspudzyxX</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>yes only 35﻿ seconds</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="npX7MMG7fT2oG2UQhKM55w"
+    data-id="994QsupBok0bg6_mr23-sMHfGvvCug4hFVbBBHOeKwY"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/Zombieskilla54" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh4.googleusercontent.com/-WiD46wSj0xg/AAAAAAAAAAI/AAAAAAAAAAA/quBAOYnWSNY/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="hernan sanchez" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/Zombieskilla54" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">hernan sanchez</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>they should﻿ rammus troll :L</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="CCwdPIaF49AUcqeusicaDw"
+    data-id="994QsupBok3q3U_2lkOBLJpkMCWXyUllblitsKeC4X4"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/channel/UCCCwdPIaF49AUcqeusicaDw" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh3.googleusercontent.com/-AywYlo679wo/AAAAAAAAAAI/AAAAAAAAAAA/HaYtioFTc3A/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Roman Hruška" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/channel/UCCCwdPIaF49AUcqeusicaDw" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Roman Hruška</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>Nice game﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment hidden flagged"
+    data-author-id="KylQAiKYZx_uCW13pT_PUg"
+    data-id="994QsupBok3q3U_2lkOBLLxs-B8Y2HCEDyEezh3DIYM"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/david76040" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/i/KylQAiKYZx_uCW13pT_PUg/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="david76040" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/david76040" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">david76040</a>
+        </span>
+      </p>
+
+        <p>
+            <em>This has been flagged as spam</em>
+
+          <span class="comment-show-hide">
+            <a class="show comment-action" data-action="show">show</a>
+
+              <a class="hide comment-action" data-action="hide">hide</a>
+              &bull;
+              <a class="comment-action" data-action="unflag">Not Spam</a>
+          </span>
+        </p>
+
+      <div class="comment-text" dir="ltr">
+        <p>karthus﻿﻿ op</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="B_Ap6G05fwI79NqmRhNI8A"
+    data-id="994QsupBok2XOXZmaEoc-Zh1BvFp0gu5UaoYoSVEpt0"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/JUSTCALLMEHJESUS" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/i/B_Ap6G05fwI79NqmRhNI8A/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="JUSTCALLMEHJESUS" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/JUSTCALLMEHJESUS" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">JUSTCALLMEHJESUS</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>THAT CURSE﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="JS4YsfqaE7lyXIx90S3lGg"
+    data-id="994QsupBok0EI2ow4MUmc0F6vcSeknvaSP2zIbHi_gM"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/wessel2138" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/i/JS4YsfqaE7lyXIx90S3lGg/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="wessel2138" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/wessel2138" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">wessel2138</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>next match nami please﻿ :D</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="2B3BuijF7KH6jGiOLVffZQ"
+    data-id="994QsupBok3NQrQ95jpn4Tc606lCuTmbEXx2RNkaWaE"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/XxspudzyxX" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/i/2B3BuijF7KH6jGiOLVffZQ/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="XxspudzyxX" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/XxspudzyxX" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">XxspudzyxX</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>voyboy op﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="G46mm0ztNWhF026sFSkXhg"
+    data-id="994QsupBok1MvvfLOHiN4vjta9Ekp-CgS-isEMeKCig"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/MoremousGaming" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/i/G46mm0ztNWhF026sFSkXhg/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="MoremousGaming" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/MoremousGaming" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">MoremousGaming</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>CURSE﻿ FTW</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="8Q3UNuQxnA-l44X0PePX3A"
+    data-id="994QsupBok1MvvfLOHiN4jzxJ8kKy4s6Dsi8aktQn7k"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/mvbthelast" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i1.ytimg.com/i/8Q3UNuQxnA-l44X0PePX3A/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="mvbthelast" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/mvbthelast" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">mvbthelast</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>Enroll in this﻿ summoner school &gt;&gt; bit.ly\best-lol-guide</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment removed"
+    data-author-id="vPVLrxVJi-p5JGsv1lRXCw"
+    data-id="994QsupBok3KQP5AcAMrZM3wLBM1h5jMbc4Q4iDPEJI"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/Arlen10" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/i/vPVLrxVJi-p5JGsv1lRXCw/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Arlen10" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p><em>Comment removed</em></p>
+      <p class="metadata">
+        <span class="author">
+Author withheld
+        </span>
+      </p>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="JonWVsM_WwiKwaF4FbVWrA"
+    data-id="994QsupBok3hu2kXOkrq-UEdQMNc6SLvSciklkxg4ic"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/AndiBraimllari" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh3.googleusercontent.com/-76gxNGz1Vpc/AAAAAAAAAAI/AAAAAAAAAAA/2idapHwKIUY/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Andi Braimllari" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/AndiBraimllari" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Andi Braimllari</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>goodnight guys﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="h0jMKBNEuxqrdudjq3tVAQ"
+    data-id="994QsupBok3hu2kXOkrq-VUqTdTjln1OlaRJoSHUHx0"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/channel/UCh0jMKBNEuxqrdudjq3tVAQ" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh4.googleusercontent.com/-5PCUWmtK4-Q/AAAAAAAAAAI/AAAAAAAAAAA/wA2NWFh4vkI/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="fanatuno eliane" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/channel/UCh0jMKBNEuxqrdudjq3tVAQ" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">fanatuno eliane</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>omg the lol in my pc not charge﻿ =P</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="c-vDbYPSrK_fahEb1OjGeA"
+    data-id="994QsupBok2P7NVwBd8W_6gnw0lt7Dw2oIoLBbq0o-Q"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/lucarioboy98" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh3.googleusercontent.com/-IiTlbJk2W0s/AAAAAAAAAAI/AAAAAAAAAAA/P5HwHYbqpQo/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Vincent Roechester" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/lucarioboy98" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Vincent Roechester</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>karthus op﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="494M5A1RHaSXyBPVOMgtJA"
+    data-id="994QsupBok23m8ZN1lA3xVB1OGuHgM-9yJ1sELmd_LQ"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/dorossaa" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i1.ytimg.com/i/494M5A1RHaSXyBPVOMgtJA/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="dorossaa" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/dorossaa" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">dorossaa</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>I hope the next match﻿ has Vi :D</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="VZflBuHIj9HJ0kDDolzOwg"
+    data-id="994QsupBok2nV_OSC8fYsc7hP5DmLILUaKtyoGGXsZY"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/channel/UCVZflBuHIj9HJ0kDDolzOwg" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh6.googleusercontent.com/-Lqszu8_skG8/AAAAAAAAAAI/AAAAAAAAAAA/8lubMGsgvDg/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Luka Zarin" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/channel/UCVZflBuHIj9HJ0kDDolzOwg" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Luka Zarin</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>gg﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="5XM61n2ntft_cmyfQkYCNA"
+    data-id="994QsupBok2TN_y2NB6mmFu4PUSVJa9MpCCVsVORRv8"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/ZezchliStudios" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i2.ytimg.com/i/5XM61n2ntft_cmyfQkYCNA/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="ZezchliStudios" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/ZezchliStudios" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">ZezchliStudios</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>who is famous in the teaams that﻿ will play now?</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="mY0GfAIYAVT7ciIC3u4WhQ"
+    data-id="994QsupBok0LfAj9LEfFsND3RR1JKMU_kM8cNH_7yO0"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/whitew0lfgr" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh6.googleusercontent.com/-Zn72ZGO7XaA/AAAAAAAAAAI/AAAAAAAAAAA/0qTCZGExdSI/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="white wolf" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/whitew0lfgr" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">white wolf</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>gg﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="rJOSfVtR_lLMP41OdpPXDg"
+    data-id="994QsupBok3JTK2xUHfH6QiGHf_bjhkBYcrdF7zZUSk"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/PineapPLUR" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh3.googleusercontent.com/-AvndnFIYozI/AAAAAAAAAAI/AAAAAAAAAAA/qCKqVcIZnnY/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Alex Rodriguez" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/PineapPLUR" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Alex Rodriguez</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>my weiner exploded﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="mY0GfAIYAVT7ciIC3u4WhQ"
+    data-id="994QsupBok2M5Rk3f0dxHvyUMeJevuGVFYC7H4mEzQo"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/whitew0lfgr" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh6.googleusercontent.com/-Zn72ZGO7XaA/AAAAAAAAAAI/AAAAAAAAAAA/0qTCZGExdSI/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="white wolf" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/whitew0lfgr" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">white wolf</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>curde or﻿ die </p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="NhiBAZOsSVr0gmIb2481lQ"
+    data-id="994QsupBok0Bmn1e7rlYz9HjhVw42NcgVpgWIifqAV4"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/Jointosss" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/i/NhiBAZOsSVr0gmIb2481lQ/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Jointosss" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/Jointosss" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Jointosss</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>there are 6﻿ matches</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="6c_XHo340V_xFVPa2HH46w"
+    data-id="994QsupBok2gZzDJp0MSBgkF7yRiUxulidrjf7S-Ldg"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/xShield48x" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/i/6c_XHo340V_xFVPa2HH46w/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="xShield48x" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/xShield48x" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">xShield48x</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>go ggu!﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="nNGSUu0sLKUMNRLeTjG-jg"
+    data-id="994QsupBok2Lx-yVkTtq4J7ozajtfjzuXxUats6g0F0"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/777lukas7771" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh4.googleusercontent.com/-SMB7zpQlb4U/AAAAAAAAAAI/AAAAAAAAAAA/tnncLvnktEg/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Lukas Visvader" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/777lukas7771" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Lukas Visvader</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>Good﻿ Game</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="tZ6A1JfGFLwy2VNt7MsYug"
+    data-id="994QsupBok3BJGeZGIvtDR4MzxcE8Pb3cyUGTCMv3NQ"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/ArzKHolLow" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh3.googleusercontent.com/-2__NmJ9-eFw/AAAAAAAAAAI/AAAAAAAAAAA/eRamvnawJqc/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="arzk hollow" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/ArzKHolLow" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">arzk hollow</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>TSM!!!﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="EU7I4PRielbrmMFKQoAjCw"
+    data-id="994QsupBok0FKJbhZsqHGUdjKPk_QfCna0zgDoIguJU"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/fyior2" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i2.ytimg.com/i/EU7I4PRielbrmMFKQoAjCw/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="fyior2" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/fyior2" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">fyior2</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>this is a﻿ stupid commentary &lt;-</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="tZ6A1JfGFLwy2VNt7MsYug"
+    data-id="994QsupBok0FKJbhZsqHGZ6PvjHIongXMp4zWHIRzaE"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/ArzKHolLow" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh3.googleusercontent.com/-2__NmJ9-eFw/AAAAAAAAAAI/AAAAAAAAAAA/eRamvnawJqc/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="arzk hollow" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/ArzKHolLow" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">arzk hollow</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>nice﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="8Q3UNuQxnA-l44X0PePX3A"
+    data-id="994QsupBok2iafcdSKtZT61msu2rDwvtLseYOYK6Ovs"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/mvbthelast" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i1.ytimg.com/i/8Q3UNuQxnA-l44X0PePX3A/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="mvbthelast" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/mvbthelast" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">mvbthelast</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>BEST league guide is here :) &gt;&gt;﻿ bit.ly\best-lol-guide</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="JS4YsfqaE7lyXIx90S3lGg"
+    data-id="994QsupBok2fAzlLbDA6Tnh0n-sleVs8xjonz2_V2sQ"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/wessel2138" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/i/JS4YsfqaE7lyXIx90S3lGg/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="wessel2138" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/wessel2138" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">wessel2138</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>i would watch ggu vs vulcun if ggu picked nami﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="h0jMKBNEuxqrdudjq3tVAQ"
+    data-id="994QsupBok2D3XBwDNbIuU-LcoBdEsYL25o4YsM_MYU"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/channel/UCh0jMKBNEuxqrdudjq3tVAQ" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh4.googleusercontent.com/-5PCUWmtK4-Q/AAAAAAAAAAI/AAAAAAAAAAA/wA2NWFh4vkI/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="fanatuno eliane" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/channel/UCh0jMKBNEuxqrdudjq3tVAQ" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">fanatuno eliane</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>2 mins and go go go﻿ goooo</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="qvS4loSGdsa4RIjK8w2dYA"
+    data-id="994QsupBok3gDa1_VbHnfa0fIVRVfq3_r2sYu_tE_GI"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/channel/UCqvS4loSGdsa4RIjK8w2dYA" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh3.googleusercontent.com/-isESm38gwpA/AAAAAAAAAAI/AAAAAAAAAAA/BTADm1Crx1k/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Justin Caldejon" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/channel/UCqvS4loSGdsa4RIjK8w2dYA" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Justin Caldejon</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>TSm is going to﻿ play Dig at 5 pacific</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="6E1oe0YeR9Nlou0klVUgAg"
+    data-id="994QsupBok3rTFKILIyTCSYsX6bPkQrviqkJVBKBsMw"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/MrKaidalen" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/i/6E1oe0YeR9Nlou0klVUgAg/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="MrKaidalen" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/MrKaidalen" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">MrKaidalen</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>kiwikid﻿ has a nose of king kong</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment removed"
+    data-author-id="EU7I4PRielbrmMFKQoAjCw"
+    data-id="994QsupBok2uEfDo_ama6YQ1TUHEDPd0msZT-HM_6gQ"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/fyior2" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i2.ytimg.com/i/EU7I4PRielbrmMFKQoAjCw/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="fyior2" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p><em>Comment removed</em></p>
+      <p class="metadata">
+        <span class="author">
+Author withheld
+        </span>
+      </p>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="BcLQ23TjzcF_aOrrgbZi9Q"
+    data-id="994QsupBok31P0okhl0JcaV1lLGVmt0vbYS1OB7rvVE"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/JayLimJX" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh6.googleusercontent.com/-suFgm6w5kk0/AAAAAAAAAAI/AAAAAAAAAAA/aA_WtezvZ5g/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Jing Xiang Lim" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/JayLimJX" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Jing Xiang Lim</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>lets﻿ take a short break </p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="lhM2ueX56OzMn7l6Zfqnew"
+    data-id="994QsupBok31P0okhl0JcctiBLBWVei7ZGfYOyxqzk8"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/119Baka119" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner">img data-thumb="//i1.ytimg.com/i/lhM2ueX56OzMn7l6Zfqnew/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="119Baka119" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/119Baka119" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">119Baka119</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>scarra﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="oO5TxP-WPmRkYE6bzjFjIA"
+    data-id="994QsupBok0YKKhZxbPFoVwL3HZBvhO_rJIQwGoCE1E"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/smoky222" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/i/oO5TxP-WPmRkYE6bzjFjIA/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="smoky222" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/smoky222" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">smoky222</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>all the﻿ good matches are over</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="UJmFNEHX2eDrLcHPOkXsHg"
+    data-id="994QsupBok3SNWAb9uhBSyYxDoKX-1tGyVsZoPW2P0E"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/xxxartureczekplxxx" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i2.ytimg.com/i/UJmFNEHX2eDrLcHPOkXsHg/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="xxxartureczekplxxx" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/xxxartureczekplxxx" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">xxxartureczekplxxx</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>Kiwikid is soo﻿ cute</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="tZ6A1JfGFLwy2VNt7MsYug"
+    data-id="994QsupBok3SNWAb9uhBS0hoqg5vAIVd601e0e2-z3w"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/ArzKHolLow" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh3.googleusercontent.com/-2__NmJ9-eFw/AAAAAAAAAAI/AAAAAAAAAAA/eRamvnawJqc/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="arzk hollow" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/ArzKHolLow" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">arzk hollow</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>LOL﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="379cV5gRskOKk39PEo5ERw"
+    data-id="994QsupBok2nBuSb0e5aWXobAc8Xw7cwJWoww6h90Q8"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/channel/UC379cV5gRskOKk39PEo5ERw" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh4.googleusercontent.com/-8HugMggZm2Y/AAAAAAAAAAI/AAAAAAAAAAA/ejRLhBsahds/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Keven Rousseau" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/channel/UC379cV5gRskOKk39PEo5ERw" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Keven Rousseau</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>Only Gambit Gaming doing the exception lol﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="JS4YsfqaE7lyXIx90S3lGg"
+    data-id="994QsupBok0toGBn_U8pWgh3_vuK2kHZRNZ79unfm1I"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/wessel2138" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/i/JS4YsfqaE7lyXIx90S3lGg/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="wessel2138" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/wessel2138" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">wessel2138</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>everybody loves﻿ scarra</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="JMYNfzLmlz08NIeN2m91pA"
+    data-id="994QsupBok0-03x7DicAYyVcwUe6CmATw79Hd4fMCEc"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/MrSoupMonster" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/i/JMYNfzLmlz08NIeN2m91pA/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="MrSoupMonster" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/MrSoupMonster" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">MrSoupMonster</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>Rofl at all the butthurt﻿ Dig fans xD They got outplayed and Curse is better, get over it!</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="Pw4gG5ZUIXuXo2KVX1x9WQ"
+    data-id="994QsupBok3Rmf4dnnQXkXXX3MWbvI-2S8HjdawHGv8"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/YourToeIsOnFire" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i1.ytimg.com/i/Pw4gG5ZUIXuXo2KVX1x9WQ/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="YourToeIsOnFire" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/YourToeIsOnFire" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">YourToeIsOnFire</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>who is cuter﻿ Kiwikid or scarra?</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="BcLQ23TjzcF_aOrrgbZi9Q"
+    data-id="994QsupBok3VKDrA9g2Y5t3cvV1eQJKM6NB_Gbfw-hs"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/JayLimJX" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh6.googleusercontent.com/-suFgm6w5kk0/AAAAAAAAAAI/AAAAAAAAAAA/aA_WtezvZ5g/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Jing Xiang Lim" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/JayLimJX" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Jing Xiang Lim</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>gg﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="Hm1QkeiFzvZu14bPFNLvjg"
+    data-id="994QsupBok3VKDrA9g2Y5jFeyPIggk3RDgfznGxyMRk"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/calibaby1" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i1.ytimg.com/i/Hm1QkeiFzvZu14bPFNLvjg/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="calibaby1" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/calibaby1" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">calibaby1</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>omg no one wants﻿ to watch ggu vs vulcun -.-</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="Ds44eCpGJH1-PKuJUuV_UA"
+    data-id="994QsupBok1v8IaUS9YFyMiUCLxwS-xcLfBu6qW66KM"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/mnnk101" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i1.ytimg.com/i/Ds44eCpGJH1-PKuJUuV_UA/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="mnnk101" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/mnnk101" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">mnnk101</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>awe....I thought﻿ TSM was going to play again today =.=</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="h0jMKBNEuxqrdudjq3tVAQ"
+    data-id="994QsupBok1SpLtL1ZnceZampbFE7duxO7Ak9jte3tc"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/channel/UCh0jMKBNEuxqrdudjq3tVAQ" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh4.googleusercontent.com/-5PCUWmtK4-Q/AAAAAAAAAAI/AAAAAAAAAAA/wA2NWFh4vkI/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="fanatuno eliane" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/channel/UCh0jMKBNEuxqrdudjq3tVAQ" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">fanatuno eliane</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>=D﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="KAnc3GGb9Kf-btnfBkyrVQ"
+    data-id="994QsupBok2a2n7Ll16q-E21VfHHF4fQ8I8OS6-MPJ8"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/ZoltaTrawa" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/i/KAnc3GGb9Kf-btnfBkyrVQ/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="ZoltaTrawa" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/ZoltaTrawa" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">ZoltaTrawa</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>lol ggu﻿ vs vulcUN ahhahahaha noone will watch this crap Kappa</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="JS4YsfqaE7lyXIx90S3lGg"
+    data-id="994QsupBok1W-n4-UVWIpGx-I4ilisHhSvQV6bOoLPo"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/wessel2138" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/i/JS4YsfqaE7lyXIx90S3lGg/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="wessel2138" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/wessel2138" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">wessel2138</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>elementz da best!﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="Pw4gG5ZUIXuXo2KVX1x9WQ"
+    data-id="994QsupBok3wYY_HdpqHb5MWPEhoREnT9QaHO46FinY"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/YourToeIsOnFire" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i1.ytimg.com/i/Pw4gG5ZUIXuXo2KVX1x9WQ/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="YourToeIsOnFire" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/YourToeIsOnFire" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">YourToeIsOnFire</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>Nice saint :)﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="ceyyCdUlbPfrnM7xNQmHDQ"
+    data-id="994QsupBok1eTQsK5q7VIlTvVipPBqOlnVSDSKWv7aE"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/Tman404ify" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/i/ceyyCdUlbPfrnM7xNQmHDQ/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Tman404ify" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/Tman404ify" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Tman404ify</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>yeah﻿ omajdascz its NA</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="BcLQ23TjzcF_aOrrgbZi9Q"
+    data-id="994QsupBok1eTQsK5q7VIlurd_ii1r5rqibKvdZ9WvY"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/JayLimJX" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh6.googleusercontent.com/-suFgm6w5kk0/AAAAAAAAAAI/AAAAAAAAAAA/aA_WtezvZ5g/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Jing Xiang Lim" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/JayLimJX" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Jing Xiang Lim</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>report cait﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="CNMWDMs_u7GaNe3DCcE7Pg"
+    data-id="994QsupBok36mtpRh5rlaoF-SYlXyqMAxoNW92NYgc0"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/tasos5283" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh3.googleusercontent.com/-0Msvqj18JBk/AAAAAAAAAAI/AAAAAAAAAAA/qOhXne0xSVg/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Tasos Kozi" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/tasos5283" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Tasos Kozi</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>almost all pro lol team members are﻿ friends :)</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="JS4YsfqaE7lyXIx90S3lGg"
+    data-id="994QsupBok05ZpV7DQHwpvZqqpeew2czpug6yikRj3Q"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/wessel2138" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/i/JS4YsfqaE7lyXIx90S3lGg/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="wessel2138" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/wessel2138" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">wessel2138</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>curse!﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="hgo7Uj0Cd01T6SW0PGutXw"
+    data-id="994QsupBok05ZpV7DQHwpj3DfJ7IBf540wkJnZfKGZ0"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/fvillalo23" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i1.ytimg.com/i/hgo7Uj0Cd01T6SW0PGutXw/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="fvillalo23" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/fvillalo23" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">fvillalo23</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>cya﻿ nerds</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="KI3i_x1uy0gZlJS3QXh4oA"
+    data-id="994QsupBok05ZpV7DQHwprrFq2BtS1cGrFz7o9fJAew"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/EuRoGuNzZeRo" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/i/KI3i_x1uy0gZlJS3QXh4oA/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="EuRoGuNzZeRo" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/EuRoGuNzZeRo" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">EuRoGuNzZeRo</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>GGU﻿ vs Vulcun lmao!</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="YF4nmFSJRFhxg0pF71Ufkg"
+    data-id="994QsupBok05ZpV7DQHwpgZ8LoY7QaJKME4SPuTARNM"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/kataminas2012" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i2.ytimg.com/i/YF4nmFSJRFhxg0pF71Ufkg/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="kataminas2012" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/kataminas2012" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">kataminas2012</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>CURSE﻿ CURSE</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="9AtafXaSsu6sp5w-iYo17w"
+    data-id="994QsupBok21kNYRUoCPap9mHQ2r4XBpgb-rt4Oka28"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/Awaken1ngs" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i2.ytimg.com/i/9AtafXaSsu6sp5w-iYo17w/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Awaken1ngs" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/Awaken1ngs" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Awaken1ngs</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>gg﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="HUc5f9wvjz8H_p4xH9QqaA"
+    data-id="994QsupBok3C5EhvnrrahfGHAY7DR0Q6hRnAEwf9oWc"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/Reichy8" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i1.ytimg.com/i/HUc5f9wvjz8H_p4xH9QqaA/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Reichy8" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/Reichy8" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Reichy8</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>nice﻿ game</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="7Z-gUOL2YafaSfXDIncXJw"
+    data-id="994QsupBok2Me_JYyWpw5kDOUuCVNFuJrlSVZS_xijs"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/TheForthSuccessor" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/i/7Z-gUOL2YafaSfXDIncXJw/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="TheForthSuccessor" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/TheForthSuccessor" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">TheForthSuccessor</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>Is﻿ it over?</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="dFD6P4rcPrVwFU4Mnkrdpw"
+    data-id="994QsupBok1egKu0sGfuGwU5ccGWNS-ah_xci-VQ8SI"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/Snipermaluko" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i1.ytimg.com/i/dFD6P4rcPrVwFU4Mnkrdpw/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Snipermaluko" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/Snipermaluko" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Snipermaluko</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>curse﻿ shut down imaqtpie, he dind&#39;t fed</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="IDFT9-39CrVdGqvzAf8Emg"
+    data-id="994QsupBok0vyvEm0yD7kjpk0_Dgk0wdPnNIlm3jyek"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/channel/UCIDFT9-39CrVdGqvzAf8Emg" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh5.googleusercontent.com/-IJbx-VYRtWs/AAAAAAAAAAI/AAAAAAAAAAA/BfwICgvBsM8/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="george greece" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/channel/UCIDFT9-39CrVdGqvzAf8Emg" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">george greece</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>lol﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="wUm3TLKYyPesHXi46MCHqA"
+    data-id="994QsupBok0gFZelDk5tgRQwVKCsPRxvj2o2FYWbO-8"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/Clem95dofus" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/i/wUm3TLKYyPesHXi46MCHqA/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Clem95dofus" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/Clem95dofus" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Clem95dofus</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>aclegendary94 -&gt; you have my﻿ photo fuck you</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="KI3i_x1uy0gZlJS3QXh4oA"
+    data-id="994QsupBok0gFZelDk5tgYYxdqkIemNRDpOAhLsWmQE"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/EuRoGuNzZeRo" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/i/KI3i_x1uy0gZlJS3QXh4oA/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="EuRoGuNzZeRo" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/EuRoGuNzZeRo" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">EuRoGuNzZeRo</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>Yes﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="J0I2Z4H4sTShOmIMZIRHeg"
+    data-id="994QsupBok1ZBulnymQ100Q928LaNhqP9R9VeEJfcQc"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/channel/UCJ0I2Z4H4sTShOmIMZIRHeg" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh6.googleusercontent.com/-UhE1UbSTpF8/AAAAAAAAAAI/AAAAAAAAAAA/h-AQYCFNKLg/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="french montana" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/channel/UCJ0I2Z4H4sTShOmIMZIRHeg" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">french montana</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>CURDE OR﻿ DIE</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="AMxPz10AUPs62kGjZNhOjw"
+    data-id="994QsupBok0n1IIEZ3FdKczOYeY4REt1i4S2KDX2ksQ"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/johnkingviii" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i2.ytimg.com/i/AMxPz10AUPs62kGjZNhOjw/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="johnkingviii" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/johnkingviii" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">johnkingviii</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>whats next?﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="IDFT9-39CrVdGqvzAf8Emg"
+    data-id="994QsupBok2hcd8M03AnMO8AJmaoY6j4gj4ipgCotjo"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/channel/UCIDFT9-39CrVdGqvzAf8Emg" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh5.googleusercontent.com/-IJbx-VYRtWs/AAAAAAAAAAI/AAAAAAAAAAA/BfwICgvBsM8/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="george greece" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/channel/UCIDFT9-39CrVdGqvzAf8Emg" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">george greece</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>dignitas﻿ was paid!!</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="_X1ijJ-Ni2PFDxuSED3vrg"
+    data-id="994QsupBok15QivxJLzc1IF2x4qtuII1iL8M5M3i13Q"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/kill4fun0000" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/i/_X1ijJ-Ni2PFDxuSED3vrg/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="kill4fun0000" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/kill4fun0000" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">kill4fun0000</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>:D﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="cAky1Y-qzJgpe_BGIc3nKA"
+    data-id="994QsupBok3Ie3irLmNkyLE0R5nlLq1iwb91QjoBtHE"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/somethingicaneat" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/i/cAky1Y-qzJgpe_BGIc3nKA/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="somethingicaneat" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/somethingicaneat" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">somethingicaneat</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>CW FTW﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="7ht9AXp-4V2ohhJjR6UYzw"
+    data-id="994QsupBok1oP38qZGZMr2oAxS6_-QwM8v0PrzWCfWw"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/defaultds" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh5.googleusercontent.com/-idX_uOduAVQ/AAAAAAAAAAI/AAAAAAAAAAA/PnjJgmftQfs/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Arnon Thome Freitas Lemos" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/defaultds" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Arnon Thome Freitas Lemos</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>DAT﻿ VOY</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="klM1easGG1C5uUb0rnHjsA"
+    data-id="994QsupBok1oP38qZGZMrx7kw3d6Dng0zYtdNPCt98c"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/Omajdascz" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/i/klM1easGG1C5uUb0rnHjsA/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Omajdascz" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/Omajdascz" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Omajdascz</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>this is﻿ NA?</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="FVXV8-W8ZYpZSlu8xhRS-w"
+    data-id="994QsupBok1omtwcokGz8EQIAnkyFTUbud56StSP3e0"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/Jurai21" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/i/FVXV8-W8ZYpZSlu8xhRS-w/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Jurai21" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/Jurai21" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Jurai21</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>I like how both teams were smiling. Nice﻿ sportsmanship</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="JlXqIEd84-jHvAsDlGRVkQ"
+    data-id="994QsupBok3jB9csnYpw4c9eIYpuaSawzf1lalWH1bY"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/jokerasho" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh5.googleusercontent.com/-jqMaxif6nGw/AAAAAAAAAAI/AAAAAAAAAAA/0vnXSt0K5ZU/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Tucki Sobran las palabras" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/jokerasho" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Tucki Sobran las palabras</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>:D﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="EDf4r33pzXEaR2opKdxefw"
+    data-id="994QsupBok0-Zz4m2mTKdH6rOlZTNKqEunDTediz8t4"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/TheNexxGeneration" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="https://lh5.googleusercontent.com/-KuQZpzFBshM/AAAAAAAAAAI/AAAAAAAAAAA/585j5QvtKgo/s28-c-k/photo.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Doktor Acula" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/TheNexxGeneration" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">Doktor Acula</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>dem﻿ curse is too srong atm</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="cAky1Y-qzJgpe_BGIc3nKA"
+    data-id="994QsupBok0-Zz4m2mTKdAKmQfPA98yERTaWpY7LESU"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/somethingicaneat" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/i/cAky1Y-qzJgpe_BGIc3nKA/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="somethingicaneat" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/somethingicaneat" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">somethingicaneat</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>hi﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+      
+
+
+  <li class="comment"
+    data-author-id="sxJ_0UgMk5R2EtusohO_KQ"
+    data-id="994QsupBok0-Zz4m2mTKdBU0i9pIrezgPxC3Blko51s"
+    >
+    <button type="button" class="flip close yt-uix-button yt-uix-button-link yt-uix-button-empty" onclick=";return false;" data-button-has-sibling-menu="true" role="button" aria-pressed="false" aria-expanded="false" aria-haspopup="true" aria-activedescendant=""><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-comment-close" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><div class=" yt-uix-button-menu yt-uix-button-menu-link" style="display: none;"><ul><li class="comment-action-remove comment-action" data-action="remove"><span class="yt-uix-button-menu-item">Remove</span></li><li class="comment-action" data-action="flag-profile-pic"><span class="yt-uix-button-menu-item">Report profile image</span></li><li class="comment-action" data-action="flag"><span class="yt-uix-button-menu-item">Flag for spam</span></li><li class="comment-action-block comment-action" data-action="block"><span class="yt-uix-button-menu-item">Block User</span></li><li class="comment-action-unblock comment-action" data-action="unblock"><span class="yt-uix-button-menu-item">Unblock User</span></li></ul></div></button>
+      <a href="/user/xMckayy" class="yt-user-photo " ><span class="video-thumb ux-thumb yt-thumb-square-28 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/i/sxJ_0UgMk5R2EtusohO_KQ/1.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="xMckayy" width="28" ><span class="vertical-align"></span></span></span></span></a>
+
+    
+
+  <div class="content">
+      <p class="metadata">
+        <span class="author ">
+          <a href="/user/xMckayy" class="yt-uix-sessionlink yt-user-name " data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg" dir="ltr">xMckayy</a>
+        </span>
+      </p>
+
+
+      <div class="comment-text" dir="ltr">
+        <p>gg﻿</p>
+
+      </div>
+  </div>
+
+
+  </li>
+
+  </ul>
+
+        <a href="/all_comments?v=S_pMsJw-_oA">
+View all Comments &raquo;
+        </a>
+    </div>
+  </div>
+
+
+
+    <ul>
+      <li class="hid" id="parent-comment-loading">Loading comment...</li>
+    </ul>
+  </div>
+  <div id="comments-loading" class="hid">Loading...</div>
+
+
+    </div>
+  </div>
+
+
+        <hr class="yt-horizontal-rule ">
+
+
+
+
+        <div id="watch-channel-brand-div" class="" >
+    <div id="watch-channel-brand-div-text">
+Advertisement
+    </div>
+    <div id="google_companion_ad_div">
+    </div>
+  </div>
+
+
+      
+  <div class="watch-sidebar-section">
+    <div class="watch-sidebar-body">
+      <ul id="watch-related" class="video-list">
+          <li class="video-list-item">
+            <a href="/watch?v=oSSlOIxK5Bc" class="related-video yt-uix-contextlink  yt-uix-sessionlink" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=relmfu&amp;ved=CAMQzRooAA">    <span class="ux-thumb-wrap contains-addto "><span class="video-thumb ux-thumb yt-thumb-default-120 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/vi/oSSlOIxK5Bc/default.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" width="120" ><span class="vertical-align"></span></span></span></span><span class="video-time">1:14:42</span>
+
+
+  <button onclick=";return false;" title="Watch Later" type="button" class="addto-button video-actions spf-nolink addto-watch-later-button yt-uix-button yt-uix-button-default yt-uix-button-short yt-uix-tooltip" data-video-ids="oSSlOIxK5Bc" role="button"><span class="yt-uix-button-content">  <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Watch Later">
+ </span></button>
+</span>
+<span dir="ltr" class="title" title="TSM vs MRN - LCS 2013 NA Spring W6D1 (English)">TSM vs MRN - LCS 2013 NA Spring W6D1 (English)</span><span class="stat attribution">by <span class="yt-user-name " dir="ltr">LoLChampSeries</span></span>        <span class="stat view-count">
+        11,446 views
+    </span>
+
+</a>
+          </li>
+          <li class="video-list-item">
+            <a href="/watch?v=IJVMZ005-ik" class="related-video yt-uix-contextlink  yt-uix-sessionlink" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=relmfu&amp;ved=CAQQzRooAQ">    <span class="ux-thumb-wrap contains-addto "><span class="video-thumb ux-thumb yt-thumb-default-120 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i2.ytimg.com/vi/IJVMZ005-ik/default.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" width="120" ><span class="vertical-align"></span></span></span></span><span class="video-time">1:04:47</span>
+
+
+  <button onclick=";return false;" title="Watch Later" type="button" class="addto-button video-actions spf-nolink addto-watch-later-button yt-uix-button yt-uix-button-default yt-uix-button-short yt-uix-tooltip" data-video-ids="IJVMZ005-ik" role="button"><span class="yt-uix-button-content">  <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Watch Later">
+ </span></button>
+</span>
+<span dir="ltr" class="title" title="CLG vs DIG - LCS 2013 NA Spring W6D1 (English)">CLG vs DIG - LCS 2013 NA Spring W6D1 (English)</span><span class="stat attribution">by <span class="yt-user-name " dir="ltr">LoLChampSeries</span></span>        <span class="stat view-count">
+        10,757 views
+    </span>
+
+</a>
+          </li>
+          <li class="video-list-item">
+            <a href="/watch?v=C9U1dyaSlY8" class="related-video yt-uix-contextlink  yt-uix-sessionlink" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=relmfu&amp;ved=CAUQzRooAg">    <span class="ux-thumb-wrap contains-addto "><span class="video-thumb ux-thumb yt-thumb-default-120 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/vi/C9U1dyaSlY8/default.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" width="120" ><span class="vertical-align"></span></span></span></span><span class="video-time">1:56:21</span>
+
+
+  <button onclick=";return false;" title="Watch Later" type="button" class="addto-button video-actions spf-nolink addto-watch-later-button yt-uix-button yt-uix-button-default yt-uix-button-short yt-uix-tooltip" data-video-ids="C9U1dyaSlY8" role="button"><span class="yt-uix-button-content">  <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Watch Later">
+ </span></button>
+</span>
+<span dir="ltr" class="title" title="FNC vs EG - LCS 2013 EU Spring W5D1 (English)">FNC vs EG - LCS 2013 EU Spring W5D1 (English)</span><span class="stat attribution">by <span class="yt-user-name " dir="ltr">LoLChampSeries</span></span>        <span class="stat view-count">
+        9,933 views
+    </span>
+
+</a>
+          </li>
+          <li class="video-list-item">
+            <a href="/watch?v=VotWnsJgXr0" class="related-video yt-uix-contextlink  yt-uix-sessionlink" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=relmfu&amp;ved=CAYQzRooAw">    <span class="ux-thumb-wrap contains-addto "><span class="video-thumb ux-thumb yt-thumb-default-120 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/vi/VotWnsJgXr0/default.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" width="120" ><span class="vertical-align"></span></span></span></span><span class="video-time">53:41</span>
+
+
+  <button onclick=";return false;" title="Watch Later" type="button" class="addto-button video-actions spf-nolink addto-watch-later-button yt-uix-button yt-uix-button-default yt-uix-button-short yt-uix-tooltip" data-video-ids="VotWnsJgXr0" role="button"><span class="yt-uix-button-content">  <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Watch Later">
+ </span></button>
+</span>
+<span dir="ltr" class="title" title="MRN vs coL - LCS 2013 NA Spring W6D2 (English)">MRN vs coL - LCS 2013 NA Spring W6D2 (English)</span><span class="stat attribution">by <span class="yt-user-name " dir="ltr">LoLChampSeries</span></span>        <span class="stat view-count">
+        5,719 views
+    </span>
+
+</a>
+          </li>
+          <li class="video-list-item">
+            <a href="/watch?v=jr3Xa14qiNI" class="related-video yt-uix-contextlink  yt-uix-sessionlink" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=relmfu&amp;ved=CAcQzRooBA">    <span class="ux-thumb-wrap contains-addto "><span class="video-thumb ux-thumb yt-thumb-default-120 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/vi/jr3Xa14qiNI/default.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" width="120" ><span class="vertical-align"></span></span></span></span><span class="video-time">1:26:46</span>
+
+
+  <button onclick=";return false;" title="Watch Later" type="button" class="addto-button video-actions spf-nolink addto-watch-later-button yt-uix-button yt-uix-button-default yt-uix-button-short yt-uix-tooltip" data-video-ids="jr3Xa14qiNI" role="button"><span class="yt-uix-button-content">  <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Watch Later">
+ </span></button>
+</span>
+<span dir="ltr" class="title" title="VUL vs CLG - LCS 2013 NA Spring W6D2 (English)">VUL vs CLG - LCS 2013 NA Spring W6D2 (English)</span><span class="stat attribution">by <span class="yt-user-name " dir="ltr">LoLChampSeries</span></span>        <span class="stat view-count">
+        12,100 views
+    </span>
+
+</a>
+          </li>
+          <li class="video-list-item">
+            <a href="/watch?v=AYMVRTANETM" class="related-video yt-uix-contextlink  yt-uix-sessionlink" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=relmfu&amp;ved=CAgQzRooBQ">    <span class="ux-thumb-wrap contains-addto "><span class="video-thumb ux-thumb yt-thumb-default-120 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i2.ytimg.com/vi/AYMVRTANETM/default.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" width="120" ><span class="vertical-align"></span></span></span></span><span class="video-time">1:37:07</span>
+
+
+  <button onclick=";return false;" title="Watch Later" type="button" class="addto-button video-actions spf-nolink addto-watch-later-button yt-uix-button yt-uix-button-default yt-uix-button-short yt-uix-tooltip" data-video-ids="AYMVRTANETM" role="button"><span class="yt-uix-button-content">  <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Watch Later">
+ </span></button>
+</span>
+<span dir="ltr" class="title" title="SK vs AAA - LCS 2013 EU Spring W5D1 (English)">SK vs AAA - LCS 2013 EU Spring W5D1 (English)</span><span class="stat attribution">by <span class="yt-user-name " dir="ltr">LoLChampSeries</span></span>        <span class="stat view-count">
+        6,197 views
+    </span>
+
+</a>
+          </li>
+          <li class="video-list-item">
+            <a href="/watch?v=w_pZ84XhyuU" class="related-video yt-uix-contextlink  yt-uix-sessionlink" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=relmfu&amp;ved=CAkQzRooBg">    <span class="ux-thumb-wrap contains-addto "><span class="video-thumb ux-thumb yt-thumb-default-120 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/vi/w_pZ84XhyuU/default.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" width="120" ><span class="vertical-align"></span></span></span></span><span class="video-time">1:02:56</span>
+
+
+  <button onclick=";return false;" title="Watch Later" type="button" class="addto-button video-actions spf-nolink addto-watch-later-button yt-uix-button yt-uix-button-default yt-uix-button-short yt-uix-tooltip" data-video-ids="w_pZ84XhyuU" role="button"><span class="yt-uix-button-content">  <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Watch Later">
+ </span></button>
+</span>
+<span dir="ltr" class="title" title="EG vs DB - LCS 2013 EU Spring W5D1 (English)">EG vs DB - LCS 2013 EU Spring W5D1 (English)</span><span class="stat attribution">by <span class="yt-user-name " dir="ltr">LoLChampSeries</span></span>        <span class="stat view-count">
+        7,896 views
+    </span>
+
+</a>
+          </li>
+          <li class="video-list-item">
+            <a href="/watch?v=wYCRgOMkz4k" class="related-video yt-uix-contextlink  yt-uix-sessionlink" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=relmfu&amp;ved=CAoQzRooBw">    <span class="ux-thumb-wrap contains-addto "><span class="video-thumb ux-thumb yt-thumb-default-120 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/vi/wYCRgOMkz4k/default.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" width="120" ><span class="vertical-align"></span></span></span></span><span class="video-time">2:44</span>
+
+
+  <button onclick=";return false;" title="Watch Later" type="button" class="addto-button video-actions spf-nolink addto-watch-later-button yt-uix-button yt-uix-button-default yt-uix-button-short yt-uix-tooltip" data-video-ids="wYCRgOMkz4k" role="button"><span class="yt-uix-button-content">  <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Watch Later">
+ </span></button>
+</span>
+<span dir="ltr" class="title" title="Fnatic Best Play Ever">Fnatic Best Play Ever</span><span class="stat attribution">by <span class="yt-user-name " dir="ltr">LoLChampSeries</span></span>        <span class="stat view-count">
+        117,202 views
+    </span>
+
+</a>
+          </li>
+          <li class="video-list-item">
+            <a href="/watch?v=rWWR-tVObMM" class="related-video yt-uix-contextlink  yt-uix-sessionlink" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=relmfu&amp;ved=CAsQzRooCA">    <span class="ux-thumb-wrap contains-addto "><span class="video-thumb ux-thumb yt-thumb-default-120 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/vi/rWWR-tVObMM/default.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" width="120" ><span class="vertical-align"></span></span></span></span><span class="video-time">2:38</span>
+
+
+  <button onclick=";return false;" title="Watch Later" type="button" class="addto-button video-actions spf-nolink addto-watch-later-button yt-uix-button yt-uix-button-default yt-uix-button-short yt-uix-tooltip" data-video-ids="rWWR-tVObMM" role="button"><span class="yt-uix-button-content">  <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Watch Later">
+ </span></button>
+</span>
+<span dir="ltr" class="title" title="Dyrus Dad">Dyrus Dad</span><span class="stat attribution">by <span class="yt-user-name " dir="ltr">LoLChampSeries</span></span>        <span class="stat view-count">
+        33,017 views
+    </span>
+
+</a>
+          </li>
+          <li class="video-list-item">
+            <a href="/watch?v=G6ItDaXOVMI" class="related-video yt-uix-contextlink  yt-uix-sessionlink" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=relmfu&amp;ved=CAwQzRooCQ">    <span class="ux-thumb-wrap contains-addto "><span class="video-thumb ux-thumb yt-thumb-default-120 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/vi/G6ItDaXOVMI/default.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" width="120" ><span class="vertical-align"></span></span></span></span><span class="video-time">1:01:56</span>
+
+
+  <button onclick=";return false;" title="Watch Later" type="button" class="addto-button video-actions spf-nolink addto-watch-later-button yt-uix-button yt-uix-button-default yt-uix-button-short yt-uix-tooltip" data-video-ids="G6ItDaXOVMI" role="button"><span class="yt-uix-button-content">  <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Watch Later">
+ </span></button>
+</span>
+<span dir="ltr" class="title" title="SK vs DB - LCS 2013 EU Spring W5D1 (English)">SK vs DB - LCS 2013 EU Spring W5D1 (English)</span><span class="stat attribution">by <span class="yt-user-name " dir="ltr">LoLChampSeries</span></span>        <span class="stat view-count">
+        9,131 views
+    </span>
+
+</a>
+          </li>
+          <li class="video-list-item">
+            <a href="/watch?v=KasOGgf0NnE" class="related-video yt-uix-contextlink  yt-uix-sessionlink" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=relmfu&amp;ved=CA0QzRooCg">    <span class="ux-thumb-wrap contains-addto "><span class="video-thumb ux-thumb yt-thumb-default-120 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/vi/KasOGgf0NnE/default.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" width="120" ><span class="vertical-align"></span></span></span></span><span class="video-time">2:18</span>
+
+
+  <button onclick=";return false;" title="Watch Later" type="button" class="addto-button video-actions spf-nolink addto-watch-later-button yt-uix-button yt-uix-button-default yt-uix-button-short yt-uix-tooltip" data-video-ids="KasOGgf0NnE" role="button"><span class="yt-uix-button-content">  <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Watch Later">
+ </span></button>
+</span>
+<span dir="ltr" class="title" title="Rivalry: CLG vs Curse">Rivalry: CLG vs Curse</span><span class="stat attribution">by <span class="yt-user-name " dir="ltr">LoLChampSeries</span></span>        <span class="stat view-count">
+        72,427 views
+    </span>
+
+</a>
+          </li>
+          <li class="video-list-item">
+            <a href="/watch?v=ES2y_TykP_A" class="related-video yt-uix-contextlink  yt-uix-sessionlink" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=relmfu&amp;ved=CA4QzRooCw">    <span class="ux-thumb-wrap contains-addto "><span class="video-thumb ux-thumb yt-thumb-default-120 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i2.ytimg.com/vi/ES2y_TykP_A/default.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" width="120" ><span class="vertical-align"></span></span></span></span><span class="video-time">2:24</span>
+
+
+  <button onclick=";return false;" title="Watch Later" type="button" class="addto-button video-actions spf-nolink addto-watch-later-button yt-uix-button yt-uix-button-default yt-uix-button-short yt-uix-tooltip" data-video-ids="ES2y_TykP_A" role="button"><span class="yt-uix-button-content">  <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Watch Later">
+ </span></button>
+</span>
+<span dir="ltr" class="title" title="Bonding with CompLexity">Bonding with CompLexity</span><span class="stat attribution">by <span class="yt-user-name " dir="ltr">LoLChampSeries</span></span>        <span class="stat view-count">
+        23,175 views
+    </span>
+
+</a>
+          </li>
+          <li class="video-list-item">
+            <a href="/watch?v=nQV66KeZ1Rg" class="related-video yt-uix-contextlink  yt-uix-sessionlink" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=relmfu&amp;ved=CA8QzRooDA">    <span class="ux-thumb-wrap contains-addto "><span class="video-thumb ux-thumb yt-thumb-default-120 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/vi/nQV66KeZ1Rg/default.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" width="120" ><span class="vertical-align"></span></span></span></span><span class="video-time">2:03</span>
+
+
+  <button onclick=";return false;" title="Watch Later" type="button" class="addto-button video-actions spf-nolink addto-watch-later-button yt-uix-button yt-uix-button-default yt-uix-button-short yt-uix-tooltip" data-video-ids="nQV66KeZ1Rg" role="button"><span class="yt-uix-button-content">  <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Watch Later">
+ </span></button>
+</span>
+<span dir="ltr" class="title" title="Copenhagen Wolves&#39; First Win">Copenhagen Wolves&#39; First Win</span><span class="stat attribution">by <span class="yt-user-name " dir="ltr">LoLChampSeries</span></span>        <span class="stat view-count">
+        14,993 views
+    </span>
+
+</a>
+          </li>
+          <li class="video-list-item">
+            <a href="/watch?v=CUu4I2JV1Wk" class="related-video yt-uix-contextlink  yt-uix-sessionlink" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=relmfu&amp;ved=CBAQzRooDQ">    <span class="ux-thumb-wrap contains-addto "><span class="video-thumb ux-thumb yt-thumb-default-120 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i4.ytimg.com/vi/CUu4I2JV1Wk/default.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" width="120" ><span class="vertical-align"></span></span></span></span><span class="video-time">3:14</span>
+
+
+  <button onclick=";return false;" title="Watch Later" type="button" class="addto-button video-actions spf-nolink addto-watch-later-button yt-uix-button yt-uix-button-default yt-uix-button-short yt-uix-tooltip" data-video-ids="CUu4I2JV1Wk" role="button"><span class="yt-uix-button-content">  <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Watch Later">
+ </span></button>
+</span>
+<span dir="ltr" class="title" title="Turning the Tides with Team Dignitas">Turning the Tides with Team Dignitas</span><span class="stat attribution">by <span class="yt-user-name " dir="ltr">LoLChampSeries</span></span>        <span class="stat view-count">
+        23,051 views
+    </span>
+
+</a>
+          </li>
+          <li class="video-list-item">
+            <a href="/watch?v=ZTKW3BiiQQ8" class="related-video yt-uix-contextlink  yt-uix-sessionlink" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=relmfu&amp;ved=CBEQzRooDg">    <span class="ux-thumb-wrap contains-addto "><span class="video-thumb ux-thumb yt-thumb-default-120 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i3.ytimg.com/vi/ZTKW3BiiQQ8/default.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" width="120" ><span class="vertical-align"></span></span></span></span><span class="video-time">3:15</span>
+
+
+  <button onclick=";return false;" title="Watch Later" type="button" class="addto-button video-actions spf-nolink addto-watch-later-button yt-uix-button yt-uix-button-default yt-uix-button-short yt-uix-tooltip" data-video-ids="ZTKW3BiiQQ8" role="button"><span class="yt-uix-button-content">  <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Watch Later">
+ </span></button>
+</span>
+<span dir="ltr" class="title" title="Meet the European Shoutcasters">Meet the European Shoutcasters</span><span class="stat attribution">by <span class="yt-user-name " dir="ltr">LoLChampSeries</span></span>        <span class="stat view-count">
+        15,456 views
+    </span>
+
+</a>
+          </li>
+          <li class="video-list-item">
+            <a href="/watch?v=YNM8pZW7bFY" class="related-video yt-uix-contextlink  yt-uix-sessionlink" data-sessionlink="ei=GWBXUdCTMY6PgALvtICQBg&amp;feature=relmfu&amp;ved=CBIQzRooDw">    <span class="ux-thumb-wrap contains-addto "><span class="video-thumb ux-thumb yt-thumb-default-120 " ><span class="yt-thumb-clip"><span class="yt-thumb-clip-inner"><img data-thumb="//i2.ytimg.com/vi/YNM8pZW7bFY/default.jpg" src="http://s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" width="120" ><span class="vertical-align"></span></span></span></span><span class="video-time">2:50</span>
+
+
+  <button onclick=";return false;" title="Watch Later" type="button" class="addto-button video-actions spf-nolink addto-watch-later-button yt-uix-button yt-uix-button-default yt-uix-button-short yt-uix-tooltip" data-video-ids="YNM8pZW7bFY" role="button"><span class="yt-uix-button-content">  <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="Watch Later">
+ </span></button>
+</span>
+<span dir="ltr" class="title" title="Copenhagen Wolves">Copenhagen Wolves</span><span class="stat attribution">by <span class="yt-user-name " dir="ltr">LoLChampSeries</span></span>        <span class="stat view-count">
+        17,515 views
+    </span>
+
+</a>
+          </li>
+      </ul>
+    </div>   </div> 
+
+        </div>
+      </div>
+    </div>
+
+      <div style="visibility: hidden; height: 0px; padding: 0px; overflow: hidden;">
+      <img src="//www.youtube-nocookie.com/gen_204?attributionpartner=RiotGamesInc%2Buser" border="0" width="1" height="1">
+
+  </div>
+
+  </div>
+</div></div></div></div><div id="footer-container"><div id="footer"><div id="footer-main"><div id="footer-logo"><a href="/" title="YouTube home"><img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="YouTube home"></a></div>  <ul class="pickers yt-uix-button-group" data-button-toggle-group="optional">
+      <li>
+          
+  <button type="button" id="yt-picker-language-button" class=" yt-uix-button yt-uix-button-default" onclick=";return false;" data-button-action="yt.www.picker.load" data-button-toggle="true" data-button-menu-id="arrow-display" data-picker-position="footer" data-picker-key="language" role="button"><span class="yt-uix-button-icon-wrapper"><img class="yt-uix-button-icon yt-uix-button-icon-footer-language" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""><span class="yt-uix-button-valign"></span></span><span class="yt-uix-button-content">  <span class="yt-picker-button-label">
+Language:
+  </span>
+  English
+ </span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""></button>
+
+
+      </li>
+      <li>
+          
+  <button type="button" id="yt-picker-country-button" class=" yt-uix-button yt-uix-button-default" onclick=";return false;" data-button-action="yt.www.picker.load" data-button-toggle="true" data-button-menu-id="arrow-display" data-picker-position="footer" data-picker-key="country" role="button"><span class="yt-uix-button-content">  <span class="yt-picker-button-label">
+Country:
+  </span>
+  Worldwide
+ </span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""></button>
+
+
+      </li>
+      <li>
+          
+  <button type="button" id="yt-picker-safetymode-button" class=" yt-uix-button yt-uix-button-default" onclick=";return false;" data-button-action="yt.www.picker.load" data-button-toggle="true" data-button-menu-id="arrow-display" data-picker-position="footer" data-picker-key="safetymode" role="button"><span class="yt-uix-button-content">  <span class="yt-picker-button-label">
+Safety:
+  </span>
+Off
+ </span><img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" alt="" title=""></button>
+
+
+      </li>
+  </ul>
+  <button onclick="yt.www.feedback.startHelp(this, yt.getConfig(&#39;FEEDBACK_LOCALE_LANGUAGE&#39;), null, null, 1699712);return false;" id="google-help" class=" yt-uix-button yt-uix-button-default" type="button"  role="button"><span class="yt-uix-button-content">  <img class="questionmark" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif">
+  <span>Help</span>
+    <img class="yt-uix-button-arrow" src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif">
+ </span></button>
+      <div id="yt-picker-language-footer"
+      class="yt-picker"
+      style="display: none"
+>
+      <p class="yt-spinner">
+      <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" class="yt-spinner-img" alt="Loading icon">
+
+    <span class="yt-spinner-message">
+Loading...
+    </span>
+  </p>
+
+  </div>
+
+      <div id="yt-picker-country-footer"
+      class="yt-picker"
+      style="display: none"
+>
+      <p class="yt-spinner">
+      <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" class="yt-spinner-img" alt="Loading icon">
+
+    <span class="yt-spinner-message">
+Loading...
+    </span>
+  </p>
+
+  </div>
+
+      <div id="yt-picker-safetymode-footer"
+      class="yt-picker"
+      style="display: none"
+>
+      <p class="yt-spinner">
+      <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif" class="yt-spinner-img" alt="Loading icon">
+
+    <span class="yt-spinner-message">
+Loading...
+    </span>
+  </p>
+
+  </div>
+
+</div><div id="footer-links"><ul id="footer-links-primary">  <li><a href="/t/about_youtube">About</a></li>
+  <li><a href="//www.youtube.com/yt/press/">Press &amp; Blogs</a></li>
+  <li><a href="//www.youtube.com/yt/copyright/">Copyright</a></li>
+  <li><a href="//www.youtube.com/yt/creators/">Creators &amp; Partners</a></li>
+  <li><a href="//www.youtube.com/yt/advertise/">Advertising</a></li>
+  <li><a href="/dev">Developers</a></li>
+</ul><ul id="footer-links-secondary">  <li><a href="/t/terms">Terms</a></li>
+  <li><a href="http://www.google.com/intl/en/policies/privacy/">Privacy</a></li>
+  <li><a href="//support.google.com/youtube/bin/request.py?contact_type=abuse&amp;hl=en-US">Safety</a></li>
+
+  <li><a href="//www.google.com/tools/feedback/intl/en/error.html" onclick="return yt.www.feedback.start(yt.getConfig(&#39;FEEDBACK_LOCALE_LANGUAGE&#39;), yt.getConfig(&#39;FEEDBACK_LOCALE_EXTRAS&#39;), null, yt.getConfig(&#39;FEEDBACK_BUCKET_ID&#39;));" id="reportbug">Send feedback</a></li>
+  <li><a href="/testtube">Try something new!</a></li>
+  <li></li>
+</ul></div>    
+</div></div>
+
+      <div class="yt-dialog hid" id="feed-privacy-lb">
+    <div class="yt-dialog-base">
+      <span class="yt-dialog-align"></span>
+      <div class="yt-dialog-fg">
+        <div class="yt-dialog-fg-content">
+          <div class="yt-dialog-loading">
+              <div class="yt-dialog-waiting-content">
+    <div class="yt-spinner-img"></div><div class="yt-dialog-waiting-text">Loading...</div>
+  </div>
+
+          </div>
+          <div class="yt-dialog-content">
+              <div id="feed-privacy-dialog">
+  </div>
+
+          </div>
+          <div class="yt-dialog-working">
+              <div id="yt-dialog-working-overlay">
+  </div>
+  <div id="yt-dialog-working-bubble">
+    <div class="yt-dialog-waiting-content">
+      <div class="yt-spinner-img"></div><div class="yt-dialog-waiting-text">Working...</div>
+    </div>
+  </div>
+
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+
+
+
+  <div id="shared-addto-menu" style="display: none;" class="hid">
+      <div class="addto-menu">
+      <div class="addto-loading loading-content">
+        <img src="//s.ytimg.com/yts/img/pixel-vfl3z5WfW.gif">
+        <span>Loading playlists...</span>
+      </div>
+  </div>
+
+  </div>
+<script>if (window.ytcsi) {ytcsi.tick("js_head");}</script>        <script id="js-3625259226" src="//s.ytimg.com/yts/jsbin/www-watch-core-vfltMsPYg.js" data-loaded="true"></script>
+
+
+  <script>
+    yt.setConfig({
+      'WATCH_DELAY_LOAD_MS': 0,
+      'WATCH_EXTRA_JS': "\/\/s.ytimg.com\/yts\/jsbin\/www-watch-extra-vflfnIS_X.js",
+      'THUMB_INIT_DELAY_MS': 0,
+      'THUMB_INIT_IN_CORE': false,
+      'WATCH_GUIDE_CSS': "http:\/\/s.ytimg.com\/yts\/cssbin\/www-guide-vflStblv0.css",
+      'WATCH_CONTEXT_CONTAINER_TEMPLATE': "    \u003cdiv id=\"context-source-container\"data-context-source=\"__source__\"data-context-image=\"__image__\"style=\"display:none;\"\u003e\u003c\/div\u003e\u003cdiv class=\"__container_classes__\"\u003e\u003cdiv class=\"guide-module-toggle context-header\"\u003e\u003cspan class=\"guide-module-toggle-icon\"\u003e\u003cspan class=\"guide-module-toggle-arrow\"\u003e\u003c\/span\u003e\u003cimg src=\"\/\/s.ytimg.com\/yts\/img\/pixel-vfl3z5WfW.gif\" alt=\"\"\u003e\u003c\/span\u003e\u003ca class=\"context-back-link yt-uix-sessionlink\" href=\"__back_link__\" data-sessionlink=\"ei=GWBXUdCTMY6PgALvtICQBg\u0026amp;feature=__feature__\"\u003e\u003cspan class=\"guide-context-image-link\"\u003e\u003cspan class=\"thumb guide-context-image\"\u003e\u003cimg id=\"context-image\" src=\"\/\/s.ytimg.com\/yts\/img\/pixel-vfl3z5WfW.gif\" alt=\"\" data-context-image=\"__image__\"\u003e\u003c\/span\u003e\u003c\/span\u003e\u003cdiv class=\"guide-module-toggle-label\"\u003e\u003ch3 class=\"context-title\"\u003e\u003cspan\u003e__headline__\u003cspan class=\"yt-badge-new\"\u003enew\u003c\/span\u003e\u003c\/span\u003e\u003c\/h3\u003e\u003cspan class=\"placeholder\" title=\"__more_from__\" dir=\"__title_dir__\"\u003e__more_from__\u003c\/span\u003e\u003c\/div\u003e\u003c\/a\u003e\u003c\/div\u003e\u003cdiv class=\"guide-module-content\"\u003e\u003chr class=\"guide-section-separator guide-context-separator-top\"\u003e\u003cul id=\"watch-context-item-list\" class=\"guide-context-item-container context-data-container yt-uix-scroller guide-context-body\" data-context-playing=\"__click_index__\" data-context-open=\"true\" data-context-subsource=\"__subsource__\" data-scroll-action=\"yt.www.watch.context.loadThumbnails\"\u003e__item_list__\u003c\/ul\u003e\u003chr class=\"guide-section-separator guide-context-separator-bottom\"\u003e\u003c\/div\u003e\u003c\/div\u003e\n",
+      'WATCH_CONTEXT_VIDEO_TEMPLATE': "    \u003cli class=\"guide-context-item context-data-item context-video yt-uix-scroller-scroll-unit __item_classes__\" data-context-item-title=\"__video_title__\" data-context-item-actionuser=\"__action_username__\" data-context-item-user=\"__user_name__\" data-context-item-views=\"__view_count__\" data-context-item-actionverb=\"__action_verb__\" data-context-item-time=\"__video_time__\" data-context-item-type=\"video\" data-context-item-id=\"__video_id__\"\u003e\u003ca href=\"\/watch?v=__video_id__\" class=\"yt-uix-contextlink yt-uix-sessionlink \" data-sessionlink=\"ei=GWBXUdCTMY6PgALvtICQBg\u0026amp;feature=__feature__\"\u003e\u003cspan class=\"video-thumb ux-thumb yt-thumb-default-40 context-video-thumb\" \u003e\u003cspan class=\"yt-thumb-clip\"\u003e\u003cspan class=\"yt-thumb-clip-inner\"\u003e\u003cimg data-thumb=\"\/\/i4.ytimg.com\/vi\/__video_id__\/default.jpg\" src=\"http:\/\/s.ytimg.com\/yts\/img\/pixel-vfl3z5WfW.gif\" data-thumb-manual=\"1\" alt=\"\" data-group-key=\"guide-context-thumbs\" width=\"40\" \u003e\u003cspan class=\"vertical-align\"\u003e\u003c\/span\u003e\u003c\/span\u003e\u003c\/span\u003e\u003c\/span\u003e\u003cspan class=\"title\"\u003e__video_title__\u003c\/span\u003e\u003cspan class=\"username\"\u003eby __user_name__\n\u003c\/span\u003e\u003cspan class=\"viewcount\"\u003e__view_count__\u003c\/span\u003e\u003cspan class=\"action\"\u003e__action_username__ __action_verb__\u003c\/span\u003e\u003c\/a\u003e\u003c\/li\u003e\n",
+      'WATCH_CONTEXT_PLAYLIST_TEMPLATE': "    \u003cli class=\"guide-context-item context-data-item context-playlist yt-uix-scroller-scroll-unit __item_classes__\" data-context-item-title=\"__playlist_title__\" data-context-item-actionuser=\"__action_username__\" data-context-item-type=\"playlist\" data-context-item-user=\"\u0026quot;__user_name__\u0026quot;\" data-context-item-count-label=\"__video_count_label__\" data-context-item-videos=\"[\u0026quot;__playlist_video_id__\u0026quot;]\" data-context-item-actionverb=\"__action_verb__\" data-context-item-count=\"__video_count__\" data-context-item-id=\"__playlist_id__\"\u003e\u003ca href=\"\/watch?v=__playlist_video_id__\u0026amp;list=__playlist_id__\" class=\"yt-uix-contextlink yt-uix-sessionlink \" data-sessionlink=\"ei=GWBXUdCTMY6PgALvtICQBg\u0026amp;feature=__feature__\"\u003e\u003cspan class=\"context-video-thumb yt-pl-thumb\"\u003e\u003cspan class=\"video-thumb ux-thumb yt-thumb-default-40 \" \u003e\u003cspan class=\"yt-thumb-clip\"\u003e\u003cspan class=\"yt-thumb-clip-inner\"\u003e\u003cimg data-thumb=\"\/\/i4.ytimg.com\/vi\/__playlist_video_id__\/default.jpg\" src=\"http:\/\/s.ytimg.com\/yts\/img\/pixel-vfl3z5WfW.gif\" data-thumb-manual=\"1\" alt=\"\" data-group-key=\"guide-context-thumbs\" width=\"40\" \u003e\u003cspan class=\"vertical-align\"\u003e\u003c\/span\u003e\u003c\/span\u003e\u003c\/span\u003e\u003c\/span\u003e  \u003cspan class=\"video-count-wrapper\"\u003e\n    \u003cspan class=\"video-count-block\"\u003e\n      \u003cspan class=\"count-label\"\u003e__video_count__\u003c\/span\u003e\n      \u003cspan class=\"text-label\"\u003e__video_count_label__\u003c\/span\u003e\n    \u003c\/span\u003e\n  \u003c\/span\u003e\n\u003c\/span\u003e\u003cspan class=\"title\"\u003e__playlist_title__\u003c\/span\u003e\u003cspan class=\"username\"\u003eby __user_name__\n\u003c\/span\u003e\u003cspan class=\"action\"\u003e__action_username__ __action_verb__\u003c\/span\u003e\u003c\/a\u003e\u003c\/li\u003e\n",
+      'WATCH_CONTEXT_APPBAR_TEMPLATE': "  \u003cli  id=\"appbar-item-context\" class=\"appbar-item\"\u003e\u003cbutton type=\"button\" class=\" yt-uix-button yt-uix-button-appbar\" onclick=\";return false;\" data-button-menu-action=\"yt.www.masthead.appbar.toggleMenu\" data-button-menu-id=\"appbar-context-menu\" role=\"button\"\u003e\u003cspan class=\"yt-uix-button-content\"\u003e\u003cspan class=\"appbar-notification-count\"\u003e__item_count__\u003c\/span\u003e__headline__\u0026nbsp;\u003cspan title=\"__more_from__\" dir=\"__title_dir__\"\u003e__more_from__\u003c\/span\u003e \u003c\/span\u003e\u003cimg class=\"yt-uix-button-arrow\" src=\"\/\/s.ytimg.com\/yts\/img\/pixel-vfl3z5WfW.gif\" alt=\"\" title=\"\"\u003e\u003c\/button\u003e\u003c\/li\u003e\n",
+      'WATCH_CONTEXT_GEN204': true,
+      'WATCH_SPF_PRELOAD': false,
+      'GUIDE_ENABLED': true,
+      'TIMING_WFF': true      });
+
+    yt.setAjaxToken('promo_ajax_token', "IEM2vPdKIA3aF5PGmA2YUx-wgcR8MTM2NDc2NzEzMEAxMzY0NjgwNzMw");
+
+    yt.setMsg({
+      'WATCH_CONTEXT_MORE_FROM': "More from",
+      'WATCH_CONTEXT_MORE_RESULTS': "More results"
+    });
+
+    
+  </script>
+
+    <script>
+    yt.setConfig({
+      'VIDEO_ID': "S_pMsJw-_oA",
+
+      'JS_PAGE_MODULES': {
+        "\/\/s.ytimg.com\/yts\/jsbin\/www_watch_mod-vfltR7UY0.js": [
+            "\/\/s.ytimg.com\/yts\/jsbin\/www_watch_commentsrealtime_mod-vflMeXSi6.js",
+            "\/\/s.ytimg.com\/yts\/jsbin\/www_watch_live_mod-vflAsuonE.js",
+          ''         ]
+      },
+
+
+      'REPORTVIDEO_JS': "\/\/s.ytimg.com\/yts\/jsbin\/www-reportvideo-vfl4TKPHm.js",
+      'REPORTVIDEO_CSS': "http:\/\/s.ytimg.com\/yts\/cssbin\/www-watch-reportvideo-vflE6AMtw.css",
+
+
+      'ENABLE_AUTO_LARGE': true,
+      'ENABLE_ASPECT_RATIO': false    });
+
+      yt.setAjaxToken('watch_actions_ajax', "PR9Y4ZESG2mvXC9IliCsMfFEBGd8MTM2NDc2NzEzMEAxMzY0NjgwNzMw");
+      yt.setAjaxToken('playlist_bar_ajax', "6CxF2Y6HxOI-zEX1ndPdragY3-p8MTM2NDc2NzEzMEAxMzY0NjgwNzMw");
+      yt.setAjaxToken('guide_ajax', "hyXb_c8zESazXLhg4_82oNSKMxp8MTM2NDc2NzEzMEAxMzY0NjgwNzMw");
+      yt.setAjaxToken('guide_channels_ajax', "MVVO3yQArcJHfdM2-Vckme2Cmz98MTM2NDc2NzEzMEAxMzY0NjgwNzMw");
+
+      yt.setConfig({
+    'EMBED_HTML_TEMPLATE': "\u003ciframe width=\"__width__\" height=\"__height__\" src=\"__url__\" frameborder=\"0\" allowfullscreen\u003e\u003c\/iframe\u003e",
+    'EMBED_HTML_URL': "http:\/\/www.youtube.com\/embed\/__videoid__"
+  });
+    yt.setAjaxToken('html5_ajax', "SQDSobdZhXGcAXlZUyAH9bkPURx8MTM2NDc2NzEzMEAxMzY0NjgwNzMw");
+    yt.setMsg('FLASH_UPGRADE', "\u003cdiv class=\"yt-alert yt-alert-default yt-alert-error  yt-alert-player\"\u003e  \u003cdiv class=\"yt-alert-icon\"\u003e\n    \u003cimg s\u0072c=\"\/\/s.ytimg.com\/yts\/img\/pixel-vfl3z5WfW.gif\" class=\"icon master-sprite\" alt=\"Alert icon\"\u003e\n  \u003c\/div\u003e\n\u003cdiv class=\"yt-alert-buttons\"\u003e\u003c\/div\u003e\u003cdiv class=\"yt-alert-content\" role=\"alert\"\u003e    \u003cspan class=\"yt-alert-vertical-trick\"\u003e\u003c\/span\u003e\n    \u003cdiv class=\"yt-alert-message\"\u003e\n            You need to upgrade your Adobe Flash Player to watch this video. \u003cbr\u003e \u003ca href=\"http:\/\/get.adobe.com\/flashplayer\/\"\u003eDownload it from Adobe.\u003c\/a\u003e\n    \u003c\/div\u003e\n\u003c\/div\u003e\u003c\/div\u003e");
+  yt.setMsg('PLAYER_FALLBACK', "The Adobe Flash Player or an HTML5 supported browser is required for video playback. \u003cbr\u003e \u003ca href=\"http:\/\/get.adobe.com\/flashplayer\/\"\u003eGet the latest Flash Player\u003c\/a\u003e \u003cbr\u003e \u003ca href=\"\/html5\"\u003eLearn more about upgrading to an HTML5 browser\u003c\/a\u003e");
+  yt.setMsg('QUICKTIME_FALLBACK', "The Adobe Flash Player or QuickTime is required for video playback. \u003cbr\u003e \u003ca href=\"http:\/\/get.adobe.com\/flashplayer\/\"\u003eGet the latest Flash Player\u003c\/a\u003e \u003cbr\u003e \u003ca href=\"http:\/\/www.apple.com\/quicktime\/download\/\"\u003eGet the latest version of QuickTime\u003c\/a\u003e");
+
+
+
+    yt.setConfig({
+      'SUBSCRIBE_AXC': "LjcuYqbVyN354XyALeAMw6H9N-B8MTM2NDc2NzEzMEAxMzY0NjgwNzMw",
+      'IS_OWNER_VIEWING': false,
+      'IS_WIDESCREEN': true,
+      'PREFER_LOW_QUALITY': false,
+      'ALLOW_EMBED': true,
+      'ALLOW_RATINGS': true,
+      'YPC_CAN_RATE_VIDEO': true,
+      'YPC_SHOW_VPPA_CONFIRM_RATING': false,
+
+
+
+
+
+
+
+
+
+
+
+      'ADS_DATA': {"afc_vars": {"alternate_ad_url": "http:\/\/www.youtube.com\/ad_frame?id=watch-channel-brand-div", "ad_channel": "8386916783+8386916781+0854550287+afv_user_lolchampseries+afv_user_id_vqRdlKsE5Q8mf8YXbdIJLw+yt_mpvid_AATZK34iwRw8E45s+yt_cid_237841+ytdevice_1+Vertical_3+Vertical_36+Vertical_211+Vertical_613+ytps_default+ytel_detailpage+afc_on_page", "language": "en", "ad_host": "ca-host-pub-9313524775892158", "ad_host_tier_id": "403863", "ad_block": "2", "ad_client": "ca-pub-6219811747049371", "ad_type": "image", "format": "300x250_as", "video_doc_id": "yt_S_pMsJw-_oA"}, "use_gut": true, "show_instream": true, "show_afc": false, "show_afv": true, "show_companion": true, "gut_vars": {"tag": "\/4061\/ytpwmpu\/main_237841"}, "show_pyv": false, "afv_vars": {"google_alternate_ad_url": "http:\/\/www.youtube.com\/ad_frame?id=watch-channel-brand-div", "google_page_url": "http:\/\/www.youtube.com\/video\/S_pMsJw-_oA", "google_ad_format": "300x250_as", "google_cust_age": "1001", "google_ad_height": "250", "google_ad_host": "ca-host-pub-9313524775892158", "google_loeid": "930901,924327", "google_video_doc_id": "yt_S_pMsJw-_oA", "google_ad_host_tier_id": "403863", "google_language": "en", "google_ad_block": "2", "google_ad_client": "ca-pub-6219811747049371", "google_ad_channel": "8386916783+8386916781+0854550288+afv_user_lolchampseries+afv_user_id_vqRdlKsE5Q8mf8YXbdIJLw+yt_mpvid_AATZK34iwRw8E45s+yt_cid_237841+ytdevice_1+Vertical_3+Vertical_36+Vertical_211+Vertical_613+ytps_default+ytel_detailpage", "google_cust_gender": "1", "google_ad_type": "image"}},
+      'PLAYBACK_ID': "AATZK34iCUtUI7Wl",
+      'PLAY_ALL_MAX': 480,
+      'IN_SIGNED_OUT_ACTION_PROMO_1': false,
+      'IN_SIGNED_OUT_ACTION_PROMO_2': false    });
+
+    yt.setMsg({
+      'LOADING': "Loading..."    });
+
+      yt.setMsg({
+    'UNBLOCK_USER': "Are you sure you want to unblock this user?",
+    'BLOCK_USER': "Are you sure you want to block this user?"
+  });
+  yt.setConfig('BLOCK_USER_AJAX_XSRF', 'session_token=HORduPxroHAyh3Ou26TJMUS8EO58MTM2NDc2NzEzMEAxMzY0NjgwNzMw');
+
+
+      
+
+  yt.setConfig({
+    'COMMENTS_CHANNEL_CREATE_URL': null,
+    'COMMENTS_SIGNIN_URL': null,
+    'COMMENTS_THRESHHOLD': -5,
+    'COMMENTS_PAGE_SIZE': 250,
+    'COMMENTS_COUNT': 3047,
+    'COMMENTS_YPC_CAN_POST_OR_REACT_TO_COMMENT': true,
+    'COMMENT_SOURCE': "ls",
+    'COMMENT_OPEN_REPLY_BOX' : false
+  });
+
+  yt.setAjaxToken('link_ajax', "HORduPxroHAyh3Ou26TJMUS8EO58MTM2NDc2NzEzMEAxMzY0NjgwNzMw");
+  yt.setAjaxToken('comment_servlet', "kXmvZgh1hnIRUN5iI32apa_JqwJ8MTM2NDc2NzEzMEAxMzY0NjgwNzMw");
+  yt.setAjaxToken('comment_voting', "7KSIGFw0Er4dSa9WHmnv8MMFjYB8MTM2NDc2NzEzMEAxMzY0NjgwNzMw");
+
+
+
+  yt.setMsg({
+    'CHARACTERS_REMAINING': {"other": "# characters remaining", "case0": "No characters remaining", "case1": "1 character remaining"},
+    'COMMENT_OK': "OK",
+    'COMMENT_BLOCKED': "You've been blocked by the owner of this video or a moderator.",
+    'COMMENT_CAPTCHAFAIL': "The response to the letters on the image was not correct, please try again.",
+    'COMMENT_PENDING': "Comment Pending Approval!",
+    'COMMENT_ERROR_EMAIL': "Error, account unverified (see email)",
+    'COMMENT_ERROR': "Error, try again",
+    'COMMENT_FAILED_MAINTENANCE': "We're currently performing site maintenace, please try later.",
+    'COMMENT_OWNER_LINKING': "Comments can't contain links, please put the link in your video description and refer to it in the comment.",
+    'FAILED_HASLINK': "Oops! Remove any web addresses and try again.",
+    'FAILED_HASTAGS': "Oops! Remove the HTML tags and try again.",
+    'FAILED_ASCIIART': "Oops! Remove the character (ascii) art and try again.",
+    'FAILED_TOOSHORT': "Oops! Your comment is too short.",
+    'FAILED_TOOLONG': "Oops! Your comment is too long.",
+    'FAILED_BADPARENT': "Oops! You cannot respond to a deleted comment.",
+    'SECONDS_REMAINING': {"other": "# seconds remaining before you can post", "case0": "You can post again", "case1": "1 second remaining before you can post"}
+  });
+
+
+      yt.setConfig({
+    'ENABLE_LIVE_COMMENTS': true,
+    'WATCH_LIVECOMMENTS_JS': "\/\/s.ytimg.com\/yts\/jsbin\/www-livecomments-vfljQTV5D.js",
+    'COMMENTS_VIDEO_ID': "S_pMsJw-_oA",
+    'COMMENTS_LATEST_TIMESTAMP': 1364680728,
+    'COMMENTS_POLLING_INTERVAL': 15000,
+    'COMMENTS_FORCE_SCROLLING': false,
+    'COMMENTS_PAGE_SIZE': 250  });
+
+  yt.setMsg({
+    'LC_COUNT_NEW_COMMENTS': "\u003ca href=\"#\" onclick=\"yt.www.watch.livecomments.showNewComments(); return false;\"\u003eShow $count new comments.\u003c\/a\u003e"
+  });
+
+
+
+
+
+    
+
+
+
+
+
+
+
+        yt.setConfig({
+        'LIVESTREAMING_CARDIO_ENABLED': true,
+        'LIVESTREAMING_CARDIO_POLLING_INTERVAL': 30000,
+
+
+      'WATCH_LIVESTREAMING_JS': "\/\/s.ytimg.com\/yts\/jsbin\/www-watch-livestreaming-vflBr01BC.js"    });
+
+
+
+
+  </script>
+
+
+<script>yt.setConfig({'EVENT_ID': "GWBXUdCTMY6PgALvtICQBg",'PAGE_NAME': "watch",'LOGGED_IN': true,'SESSION_INDEX': 0,'CURRENT_URL': "http:\/\/www.youtube.com\/watch?v=S_pMsJw-_oA",'JS_COMMON_MODULE': "\/\/s.ytimg.com\/yts\/jsbin\/www_common_mod-vflE1RLJZ.js",'SAFETY_MODE_PENDING': false,'GOOGLEPLUS_HOST': "https:\/\/plus.google.com",'GAPI_HINT_PARAMS': "m;\/_\/scs\/abc-static\/_\/js\/k=gapi.gapi.en.trl52WDQBdM.O\/m=__features__\/am=QA\/rt=j\/d=1\/rs=AItRSTODqN2nSujnGEZhOle1Tw5SK0_ZGQ",'SANDBAR_ENABLED': true,'SANDBAR_LOCALE': "en-US",'SANDBAR_DELEGATED_SESSION_ID': null,'RHS_DO_NOT_FETCH_ON_SUBSCRIPTION': false,'FEEDBACK_BUCKET_ID': "Watch",'FEEDBACK_LOCALE_LANGUAGE': "en",'FEEDBACK_LOCALE_EXTRAS': {"experiments": "930901,924327,932000,906383,902000,919512,929903,931202,900821,900823,931203,931401,908529,919373,930803,906836,920201,929602,930101,930603,926403,900824,910223", "logged_in": true, "guide_subs": 4, "is_partner": false, "accept_language": "en-US,en;q=0.8", "is_branded": false}});yt.setMsg({'ADDTO_WATCH_LATER_ADDED': "Added",'ADDTO_WATCH_LATER_ERROR': "Error"});    yt.setAjaxToken('subscription_ajax', "-xBR9QOBryNIuXLitkuKXIWDn4R8MTM2NDc2NzEzMEAxMzY0NjgwNzMw");
+yt.setAjaxToken('addto_ajax', "ULhcg_1QURi5JNbivVkcJot1MI18MTM2NDc2NzEzMEAxMzY0NjgwNzMw");yt.setAjaxToken('channel_details_ajax', "smAt6ekrMI3RReWNDgm_ZhM2AWh8MTM2NDc2NzEzMEAxMzY0NjgwNzMw");  yt.setConfig('FEED_PRIVACY_CSS_URL', "http:\/\/s.ytimg.com\/yts\/cssbin\/www-feedprivacydialog-vflcKHrvr.css");
+  yt.setAjaxToken('feed_privacy_ajax', "DTsLZrjc9li1X0nirrruKOVslxF8MTM2NDc2NzEzMEAxMzY0NjgwNzMw");
+    yt.setConfig('FEED_PRIVACY_LIGHTBOX_ENABLED', true);
+yt.setConfig({'SBOX_JS_URL': "\/\/s.ytimg.com\/yts\/jsbin\/www-searchbox-vflXFKvrj.js",'SBOX_SETTINGS': {"REQUEST_LANGUAGE": "en", "CLOSE_ICON_URL": "\/\/s.ytimg.com\/yts\/img\/icons\/close-vflrEJzIW.png", "REQUEST_DOMAIN": "us", "HAS_ON_SCREEN_KEYBOARD": false, "PSUGGEST_TOKEN": "HOJXNPT9a6ixaRDFjwp8WA", "USE_HTTPS": true, "CHIP_PARAMETERS": {}, "SHOW_CHIP": false, "IS_HH": true, "EXPERIMENT_ID": -1, "SESSION_INDEX": 0},'SBOX_LABELS': {"SUGGESTION_DISMISS_LABEL": "Dismiss", "SUGGESTION_DISMISSED_LABEL": "Suggestion dismissed"}});  yt.setConfig({
+    'YPC_LOADER_ENABLED': true,
+    'YPC_LOADER_CONFIGS': "\/ypc_config_ajax",
+    'YPC_LOADER_JS': "\/\/s.ytimg.com\/yts\/jsbin\/www-ypc-vflm9CXCj.js",
+    'YPC_LOADER_CSS': "http:\/\/s.ytimg.com\/yts\/cssbin\/www-ypc-vflxILaEZ.css",
+    'YPC_LOADER_CALLBACKS': ['yt.www.ypc.checkout.init', 'yt.www.ypc.subscription.init']
+  });
+    yt.setAjaxToken('transaction_handler', "q4nxaZx9pVBs0PNhKnOYrfZmpXt8MTM2NDc2NzEzMEAxMzY0NjgwNzMw");
+  yt.setConfig({
+    'SUBSCRIPTION_URL': "\/subscription_ajax",
+    'YPC_SIGNIN_URL': "https:\/\/accounts.google.com\/ServiceLogin?passive=true\u0026service=youtube\u0026uilel=3\u0026continue=http%3A%2F%2Fwww.youtube.com%2Fsignin%3Faction_handle_signin%3Dtrue%26hl%3Den_US%26next%3D%252F%26nomobiletemp%3D1\u0026hl=en_US\u0026authuser=0",
+    'YPC_GB_LANGUAGE': "en_US",
+    'YPC_GB_URL': "https:\/\/checkout.google.com\/inapp\/lib\/buy.js",
+    'YPC_SUBSCRIPTION_URL': "\/ypc_subscription_ajax",
+    'YPC_TRANSACTION_URL': "\/transaction_handler",
+    'YPC_SUBSCRIPTION_URL': "\/ypc_subscription_ajax"
+  });
+  yt.setMsg({
+    'YPC_MSG_COUPON_ERROR': "Error applying a coupon.",
+    'YPC_MSG_COUPON_EMPTY': "Invalid coupon code. Please try again."
+  });
+
+    yt.setAjaxToken('transaction_handler', "q4nxaZx9pVBs0PNhKnOYrfZmpXt8MTM2NDc2NzEzMEAxMzY0NjgwNzMw");
+  yt.setAjaxToken('subscription_ajax', "-xBR9QOBryNIuXLitkuKXIWDn4R8MTM2NDc2NzEzMEAxMzY0NjgwNzMw");
+  yt.setMsg({
+    'YPC_SUBSCRIPTION_URL': "\/ypc_subscription_ajax",
+    'YPC_UNSUBSCRIBE_URL': "\/transaction_handler",
+    'YPC_UNSUBSCRIBE_OVERLAY': "  \u003cdiv id=\"ypc-unsubscribe-overlay\" class=\"yt-uix-overlay\" data-disable-shortcuts=\"true\"\u003e\n    \u003cspan class=\"yt-uix-overlay-target\"\u003e\u003c\/span\u003e\n        \u003cdiv class=\"yt-dialog hid\" \u003e\n    \u003cdiv class=\"yt-dialog-base\"\u003e\n      \u003cspan class=\"yt-dialog-align\"\u003e\u003c\/span\u003e\n      \u003cdiv class=\"yt-dialog-fg\"\u003e\n        \u003cdiv class=\"yt-dialog-fg-content\"\u003e\n          \u003cdiv class=\"yt-dialog-loading\"\u003e\n              \u003cdiv class=\"yt-dialog-waiting-content\"\u003e\n    \u003cdiv class=\"yt-spinner-img\"\u003e\u003c\/div\u003e\u003cdiv class=\"yt-dialog-waiting-text\"\u003eLoading...\u003c\/div\u003e\n  \u003c\/div\u003e\n\n          \u003c\/div\u003e\n          \u003cdiv class=\"yt-dialog-content\"\u003e\n              \u003cdiv class=\"ypc-unsubscribe-overlay\"\u003e\n      \u003cdiv class=\"ypc-unsubscribe-overlay-title unsubscribe-confirm\"\u003e\nAre you sure you want to unsubscribe?\n  \u003c\/div\u003e\n\n  \u003cdiv class=\"ypc-unsubscribe-overlay-title unsubscribe-loading\"\u003e\nLoading...\n  \u003c\/div\u003e\n\n  \u003cdiv class=\"ypc-unsubscribe-overlay-title unsubscribe-success unsubscribe-delayed\"\u003e\nSubscription canceled\n  \u003c\/div\u003e\n\n  \u003cdiv class=\"ypc-unsubscribe-overlay-title unsubscribe-error\"\u003e\nError canceling subscription.\n  \u003c\/div\u003e\n\n    \u003cdiv class=\"ypc-unsubscribe-overlay-data\"\u003e\n        \u003cdiv class=\"ypc-unsubscribe-overlay-content unsubscribe-confirm ypc-unsubscribe-overlay-confirm-content\"\u003e\n    \u003cdiv class=\"ypc-unsubscribe-overlay-content-message\"\u003e\n      Your subscription will be canceled when you unsubscribe. Your credit card will no longer be charged. You will still be able to access content until the billing cycle ends.\n\n    \u003c\/div\u003e\n  \u003c\/div\u003e\n\n  \u003cdiv class=\"ypc-unsubscribe-overlay-content unsubscribe-loading\"\u003e\n      \u003cp class=\"yt-spinner\"\u003e\n      \u003cimg s\u0072c=\"\/\/s.ytimg.com\/yts\/img\/pixel-vfl3z5WfW.gif\" class=\"yt-spinner-img\" alt=\"Loading icon\"\u003e\n\n    \u003cspan class=\"yt-spinner-message\"\u003e\n        Processing cancellation request...\n    \u003c\/span\u003e\n  \u003c\/p\u003e\n\n  \u003c\/div\u003e\n\n  \u003cdiv class=\"ypc-unsubscribe-overlay-content unsubscribe-success\"\u003e\n    \u003cp\u003e\nYou have successfully canceled future payments for this subscription.\n    \u003c\/p\u003e\n  \u003c\/div\u003e\n\n  \u003cdiv class=\"ypc-unsubscribe-overlay-content unsubscribe-delayed\"\u003e\n    \u003cp\u003e\nYour subscription was canceled. The status displayed in your account will update soon.\n    \u003c\/p\u003e\n  \u003c\/div\u003e\n\n  \u003cdiv class=\"ypc-unsubscribe-overlay-content unsubscribe-error\"\u003e\n    \u003cp\u003eSorry, there was an error trying to cancel your subscription; please try again later.\u003c\/p\u003e\n  \u003c\/div\u003e\n\n          \u003cdiv class=\"ypc-unsubscribe-overlay-controls unsubscribe-confirm clearfix\"\u003e\n    \u003ca href=\"\/\/support.google.com\/youtube\/?p=unsubscribe_help\" class=\"yt-uix-button  ypc-unsubscribe-help yt-uix-sessionlink yt-uix-button-default\" data-sessionlink=\"ei=GWBXUdCTMY6PgALvtICQBg\" target=\"_blank\"\u003e\u003cspan class=\"yt-uix-button-content\"\u003eHelp\u003c\/span\u003e\u003c\/a\u003e\n\n    \u003cbutton type=\"button\" class=\"yt-uix-overlay-close yt-uix-button yt-uix-button-default\" onclick=\";return false;\"  role=\"button\"\u003e\u003cspan class=\"yt-uix-button-content\"\u003eKeep subscription \u003c\/span\u003e\u003c\/button\u003e\n\n    \u003cbutton type=\"button\" class=\"ypc-unsubscribe-confirm yt-uix-button yt-uix-button-primary\" onclick=\";return false;\" data-url=\"\/transaction_handler\" role=\"button\"\u003e\u003cspan class=\"yt-uix-button-content\"\u003eUnsubscribe \u003c\/span\u003e\u003c\/button\u003e\n  \u003c\/div\u003e\n\n\n  \u003cdiv class=\"ypc-unsubscribe-overlay-controls unsubscribe-success unsubscribe-delayed unsubscribe-error\"\u003e\n    \u003cbutton type=\"button\" class=\"yt-uix-overlay-close yt-uix-button yt-uix-button-primary\" onclick=\";return false;\"  role=\"button\"\u003e\u003cspan class=\"yt-uix-button-content\"\u003eClose \u003c\/span\u003e\u003c\/button\u003e\n  \u003c\/div\u003e\n\n    \u003c\/div\u003e\n  \u003c\/div\n\n          \u003c\/div\u003e\n          \u003cdiv class=\"yt-dialog-working\"\u003e\n              \u003cdiv id=\"yt-dialog-working-overlay\"\u003e\n  \u003c\/div\u003e\n  \u003cdiv id=\"yt-dialog-working-bubble\"\u003e\n    \u003cdiv class=\"yt-dialog-waiting-content\"\u003e\n      \u003cdiv class=\"yt-spinner-img\"\u003e\u003c\/div\u003e\u003cdiv class=\"yt-dialog-waiting-text\"\u003eWorking...\u003c\/div\u003e\n    \u003c\/div\u003e\n  \u003c\/div\u003e\n\n          \u003c\/div\u003e\n        \u003c\/div\u003e\n      \u003c\/div\u003e\n    \u003c\/div\u003e\n  \u003c\/div\u003e\n\n\n  \u003c\/div\u003e\n"
+  });
+
+</script>    <script>
+yt.setConfig({'TIMING_ACTION': "watch7ad",'TIMING_INFO': {"mod_lt": "cold", "mod_ad": 1, "mod_spf": 0, "mod_pt": "flash", "mod_li": 1, "st": 537, "ei": "GWBXUdCTMY6PgALvtICQBg", "mod_ad_pr": 1, "mod_ad_an": "aftv,dclk", "e": "930901,924327,932000,906383,902000,919512,929903,931202,900821,900823,931203,931401,908529,919373,930803,906836,920201,929602,930101,930603,926403,900824,910223"}});    </script>
+<script>yt.setConfig({'XSRF_TOKEN': "jaXI351pOqXrqKhps9PiRIiCBE58MTM2NDc2NzEyOUAxMzY0NjgwNzI5",'XSRF_REDIRECT_TOKEN': "aa4OgNWxi95WhCb9HcWTKKxmo0d8MTM2NDY5NTEzMEAxMzY0NjgwNzMw",'XSRF_FIELD_NAME': "session_token"});</script><script>yt.setConfig('THUMB_DELAY_LOAD_BUFFER', 0);</script><script>if (window.ytcsi) {ytcsi.tick("js_foot");}</script><div id="debug"></div></body></html>
+


### PR DESCRIPTION
Example: www.youtube.com/watch?v=S_pMsJw-_oA

If you go on a youtube live stream that only provides a hls url, we should not fail to find a youtube video url but instead load the hls url. 

I ended up not supplementing the video quality selection because hls is adaptive and will select the best quality given the current network quality. 

Added a unit test case as well. Let me know if you need anything else..
