### PR TITLE
Prefer the old url_encoded_fmt_stream_map instead of hls because xbmc does not support seeking for hls

### DIFF
--- a/plugin/YouTubePlayer.py
+++ b/plugin/YouTubePlayer.py
@@ -254,7 +254,7 @@ class YouTubePlayer():
     def checkForErrors(self, video):
         status = 200
 
-        if video[u"video_url"] == u"":
+        if "video_url" not in video or video[u"video_url"] == u"":
             status = 303
             vget = video.get
             if vget(u"live_play"):


### PR DESCRIPTION
While xbmc does support HLS, the seek is broken which makes it impossible to seek around a live stream. Therefore, we should work around the HLS issue in xbmc by using the url_encoded_fmt_stream_map if it is available. That way, we'll  still be able to seek. 

In the case where only HLS is available, we're SOL until seek is fixed in xbmc. However, on the bright side, at least HLS works. :)
