### PR TITLE
When using play all on a playlist, nothing happens

### DIFF
--- a/plugin/YouTubePlaylistControl.py
+++ b/plugin/YouTubePlaylistControl.py
@@ -54,6 +54,7 @@ class YouTubePlaylistControl():
             result = self.getYouTubeTop100(params)
         elif get("playlist"):
             params["user_feed"] = "playlist"
+            params["login"] = "true"
             result = self.getUserFeed(params)
         elif get("user_feed") in ["recommended", "watch_later", "newsubscriptions", "favorites"]:
             params["login"] = "true"


### PR DESCRIPTION
When using play all on a playlist, nothing happens. The reason is that
the playlist is empty if we don't login. Play all work as expected if I add this line.

I have only tested this on my xbmcbuntu with a configured youtube user (actually a gmail login).

Tested on:
XBMC (13.0-ALPHA2 Git:194c408), Platform: Linux (Ubuntu 12.04.2 LTS, 3.2.0-34-generic-pae i686). Built on Apr  1 2013
