### PR TITLE
Fix playback of "possibly inappropriate" videos

### DIFF
--- a/plugin/YouTubePlayer.py
+++ b/plugin/YouTubePlayer.py
@@ -398,13 +398,16 @@ class YouTubePlayer():
         else:
             self.common.log(u'Unable to decrypt signature, key length %d not supported; retrying might work' % (len(s)))
 
-    def getVideoPageFromYoutube(self, get):
+    def getVideoPageFromYoutube(self, get, has_verified = False):
         login = "false"
+        verify = ""
 
         if self.pluginsettings.userHasProvidedValidCredentials():
             login = "true"
+            if has_verified:
+                verify = u"&has_verified=1"
 
-        page = self.core._fetchPage({u"link": self.urls[u"video_stream"] % get(u"videoid"), "login": login})
+        page = self.core._fetchPage({u"link": (self.urls[u"video_stream"] % get(u"videoid")) + verify, "login": login})
         self.common.log("Step1: " + repr(page["content"].find("ytplayer")))
 
         if not page:
@@ -425,8 +428,7 @@ class YouTubePlayer():
         if self.isVideoAgeRestricted(result):
             self.common.log(u"Age restricted video")
             if self.pluginsettings.userHasProvidedValidCredentials():
-                self.login._httpLogin({"new":"true"})
-                result = self.getVideoPageFromYoutube(get)
+                result = self.getVideoPageFromYoutube(get, True)
             else:
                 video[u"apierror"] = self.language(30622)
 


### PR DESCRIPTION
Here, watching "possibly inappropriate" videos has never worked - that's with XBMC + YouTube plugin versions from about December 2012 on.

Example video: http://www.youtube.com/watch?v=8n1OJoHpDSc

Lately, the "Cannot play video" error toast has changed to "This video may be inappropriate for some users"; i.e. it shows the message returned by YT.

I've taken this as an excuse to look into the issue, YouTube delivers a page with some markup in place of the video which contains an "I understand and wish to proceed" submit button.
After some redirects, this leads to the original `watch?v=...` page, with another parameter added.

I've added this parameter to request URLs in the appropriate case, now those videos play correctly.

I noticed that the re-login which used to be performed by the code is not necessary here - does this take care of a specific (other) scenario?

A preventive "sorry" for the code quality - Python is not one of my native languages ;-)
Feel free to clean it up in any way or tell me how it can be improved.
