### PR TITLE
Allow >50 results per (channel) video list page, by fetching multiple chunks per page

### DIFF
--- a/plugin/YouTubePluginSettings.py
+++ b/plugin/YouTubePluginSettings.py
@@ -24,7 +24,7 @@ class YouTubePluginSettings():
         self.dbg = sys.modules["__main__"].dbg
 
     def itemsPerPage(self):
-        return (10, 15, 20, 25, 30, 40, 50)[int(self.settings.getSetting("perpage"))]
+        return (10, 25, 50, 100, 250, 500)[int(self.settings.getSetting("perpage"))]
 
     def currentRegion(self):
         return ('', 'AU', 'BR', 'CA', 'CZ', 'FR', 'DE', 'GB', 'NL', 'HK', 'IN', 'IE', 'IL', 'IT', 'JP', 'MX', 'NZ', 'PL', 'RU', 'KR', 'ES', 'SE', 'TW', 'US', 'ZA')[int(self.settings.getSetting("region_id"))]

--- a/plugin/YouTubeScraper.py
+++ b/plugin/YouTubeScraper.py
@@ -127,7 +127,7 @@ class YouTubeScraper():
         result = []
         next = 'false'
         page = int(get("page", "0"))
-        per_page = (10, 15, 20, 25, 30, 40, 50,)[int(self.settings.getSetting("perpage"))]
+        per_page = (10, 25, 50, 100, 250, 500,)[int(self.settings.getSetting("perpage"))]
 
         if get("page"):
             del params["page"]

--- a/plugin/resources/settings.xml
+++ b/plugin/resources/settings.xml
@@ -19,7 +19,7 @@
   <!-- Advanced -->
   <category label="30260">
     <setting id="list_view" type="enum" label="30259" lvalues="30271|30272|30273" default="0" />
-    <setting id="perpage" type="enum" label="30210" values="10|15|20|25|30|40|50" default="6" />
+    <setting id="perpage" type="enum" label="30210" values="10|25|50|100|250|500" default="2" />
     <setting id="saved_searches" type="enum" label="30211" values="10|20|30|40" default="3" />
     <setting type="sep" />
     <setting id="region_id" type="enum" label="30221" lvalues="30222|30223|30224|30225|30226|30227|30228|30229|30230|30231|30232|30233|30234|30235|30236|30237|30238|30239|30240|30241|30242|30243|30244|30245" default="0" />


### PR DESCRIPTION
YouTube limits the number of videos per channel list result page to 50.

This is cumbersome for channels with a large number of videos, i.e. the 'TEDtalksDirector' "uploaded videos" list of almost 1500 videos - they're broken down into 30 pages [which due to the way XBMC works all have to be individually set to the preferred style and sorted by date].

Since I wanted a "couch-compatible" solution to watching the TED talks in chronological order, I took a look at this and implemented a patch that aggregates up to 500 videos into a single video list page, by concatenating the data from multiple YouTube result pages.

This code has been in "production use" here for about 4 months already, I only just found the "new" plugin source repo to submit the patch to.

Again, sorry for "code quality"; just tell me what/how should be cleaned up.
