### PR TITLE
change duration to seconds and add to XBMC via StreamInfo

### DIFF
--- a/plugin/YouTubeCore.py
+++ b/plugin/YouTubeCore.py
@@ -759,7 +759,6 @@ class YouTubeCore():
         result = 1
 
         for tmp in self.common.parseDOM(node, "yt:duration", ret="seconds"):
-            tmp = int(tmp) / 60
             if tmp:
                 result = tmp
 

--- a/plugin/YouTubeNavigation.py
+++ b/plugin/YouTubeNavigation.py
@@ -442,6 +442,7 @@ class YouTubeNavigation():
 
         listitem.setProperty("Video", "true")
         listitem.setProperty("IsPlayable", "true")
+        listitem.addStreamInfo('video', {'duration': item_params.pop('Duration')})
         listitem.setInfo(type='Video', infoLabels=item_params)
         self.xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url=url, listitem=listitem, isFolder=False, totalItems=listSize + 1)
         self.common.log("Done", 5)


### PR DESCRIPTION
Since XBMC Frodo the video duration needs to be set in seconds via

``` python
ListItem.addStreamInfo('video': {'duration': duration_in_seconds})
```

I didn't changed the unittests because I think they will continue work, ping me if they need to be changed.
