### PR TITLE
UTF-8 login fix for Frodo

### DIFF
--- a/YouTubeCore.py
+++ b/YouTubeCore.py
@@ -397,6 +397,7 @@ class YouTubeCore():
             return ret_obj
 
         if get("url_data"):
+            params["url_data"] = dict((k, v.encode('utf-8')) for (k, v) in get("url_data").items())
             request = urllib2.Request(link, urllib.urlencode(get("url_data")))
             request.add_header('Content-Type', 'application/x-www-form-urlencoded')
         elif get("request", "false") == "false":


### PR DESCRIPTION
Hey!

The issue fixed in https://github.com/HenrikDK/youtube-xbmc-plugin/pull/10 was not got pulled to the `frodo` branch, thus make the plugin unusable when UTF-8 characters are met during login (most of Central-European accounts)

The fix commited was found found in https://code.google.com/p/youtubexbmc/issues/detail?id=106 

Regards:
obrien
