### PR TITLE
Newlines in the search string lead to "Could not connect to network server" error

### DIFF
--- a/plugin/YouTubeNavigation.py
+++ b/plugin/YouTubeNavigation.py
@@ -167,7 +167,7 @@ class YouTubeNavigation():
         results = []
         if (get("feed") == "search" or get("scraper") == "search_disco"):
             if not get("search"):
-                query = self.common.getUserInput(self.language(30006), '')
+                query = self.common.getUserInput(self.language(30006), '').strip()
                 if not query:
                     return False
                 params["search"] = query


### PR DESCRIPTION
Leading/trailing spaces in search string are useless anyway and given that search query is not url-encoded stuff like trailing newlines (which xbmcRemote iPhone app seems to add) leads to invalid URL. Which in turn leads to "Could not connect to network server" error.

Calling strip() on user input fixes this.
