### PR TITLE
Fix HTTPS streams that use RC4-SHA on recent libcurl versions

### DIFF
--- a/plugin/YouTubePlayer.py
+++ b/plugin/YouTubePlayer.py
@@ -219,7 +219,10 @@ class YouTubePlayer():
             return video_url
 
         if get("action") != "download" and video_url.find("rtmp") == -1:
-            video_url += '|' + urllib.urlencode({'User-Agent':self.common.USERAGENT})
+            video_url += '|' + urllib.urlencode({
+                               'User-Agent':self.common.USERAGENT,
+                               "SSLCipherList":"DEFAULT:RC4-SHA", # Recent versions of libcurl disable RC4-SHA by default.
+                               })
 
         self.common.log(u"Done")
         return video_url


### PR DESCRIPTION
ported Orochimarufan change (https://github.com/Gentro/youtube-xbmc-plugin/pull/1) to henrikdk base

Ubuntu users also need to rebuild PyCurl against libcurl-openssl (vs libcurl-gnutls that it ships with by default) before this will work. https://gist.github.com/aerickson/f15133a7e56b2d7f27e3

...

As per xbmc/xbmc#4489

YouTube still uses the obsolete RC4-SHA cipher for video streams.
Recent libcurl version disable it for security reasons.
